### PR TITLE
fix(ci): pin cosign CLI to 2.6.3 to unblock release signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,12 @@ jobs:
       # Sigstore keyless signing requires cosign on the runner.
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          # Pin cosign CLI to 2.x: cosign 4.x changed keyless sign-blob to
+          # require the new bundle format, breaking --output-signature /
+          # --output-certificate signing (create bundle file: open : no such
+          # file). v4 flag migration is a follow-up.
+          cosign-release: 'v2.6.3'
 
       # SBOM generation requires syft on the runner.
       - name: Install syft


### PR DESCRIPTION
cosign 4.x (installer bump #67) broke keyless sign-blob signing — `create bundle file: open : no such file`, failing the v1.16.0 release. Pin `cosign-release: v2.6.3` to restore signing. v4 flag migration is a follow-up.