### PR TITLE
fix(release): migrate cosign signing to v4 bundle format

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,12 +29,6 @@ jobs:
       # Sigstore keyless signing requires cosign on the runner.
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
-        with:
-          # Pin cosign CLI to 2.x: cosign 4.x changed keyless sign-blob to
-          # require the new bundle format, breaking --output-signature /
-          # --output-certificate signing (create bundle file: open : no such
-          # file). v4 flag migration is a follow-up.
-          cosign-release: 'v2.6.3'
 
       # SBOM generation requires syft on the runner.
       - name: Install syft

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -56,13 +56,11 @@ signs:
   - id: cosign-checksums
     cmd: cosign
     artifacts: checksum
-    signature: '${artifact}.sig'
-    certificate: '${artifact}.pem'
+    signature: '${artifact}.sigstore.json'
     args:
       - sign-blob
       - '--yes'
-      - '--output-signature=${signature}'
-      - '--output-certificate=${certificate}'
+      - '--bundle=${signature}'
       - '${artifact}'
     output: true
 


### PR DESCRIPTION
Real v4 fix: goreleaser signs use `--bundle` (.sigstore.json) instead of removed `--output-signature`/`--output-certificate`; cosign CLI pin dropped (v4).