### PR TITLE
chore: publish Homebrew formula via klarlabs-studio/homebrew-tap

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Works best on standard Go/Python/JavaScript/Java/Rust projects with conventional
 ## Get started
 
 ```bash
-brew install felixgeelhaar/tap/coverctl
+brew install klarlabs-studio/tap/coverctl
 ```
 
 Wire into Claude Code (`~/.config/claude-code/mcp.json`):

--- a/docs/src/content/docs/agent-loop-tutorial.mdx
+++ b/docs/src/content/docs/agent-loop-tutorial.mdx
@@ -33,7 +33,7 @@ Claude Code (or Cursor or Cline) already installed.
 1. **Install coverctl and `coverctl init`**
 
    ```bash
-   brew install felixgeelhaar/tap/coverctl   # or: go install go.klarlabs.de/coverctl@latest
+   brew install klarlabs-studio/tap/coverctl   # or: go install go.klarlabs.de/coverctl@latest
    cd your-project
    coverctl init
    ```

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -105,7 +105,7 @@ Working from a terminal instead? [Terminal quickstart →](/coverctl/quick-start
 
 ```bash
 # Install
-brew install felixgeelhaar/tap/coverctl   # or: go install go.klarlabs.de/coverctl@latest
+brew install klarlabs-studio/tap/coverctl   # or: go install go.klarlabs.de/coverctl@latest
 
 # One-time project setup
 coverctl init

--- a/docs/src/content/docs/installation.mdx
+++ b/docs/src/content/docs/installation.mdx
@@ -10,7 +10,7 @@ coverctl is a single self-contained binary. It runs locally — no SaaS account,
 ## Recommended: prebuilt binary via Homebrew
 
 ```bash
-brew install felixgeelhaar/tap/coverctl
+brew install klarlabs-studio/tap/coverctl
 ```
 
 Works on macOS and Linux. Same binary runs the CLI and the MCP server (`coverctl mcp serve`) the agent calls.

--- a/scripts/update-homebrew-tap.sh
+++ b/scripts/update-homebrew-tap.sh
@@ -36,14 +36,14 @@ CRED_FILE=$(mktemp)
 trap 'rm -f "$CRED_FILE"' EXIT
 echo "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com" > "$CRED_FILE"
 git config --global credential.helper "store --file=${CRED_FILE}"
-git clone "https://github.com/felixgeelhaar/homebrew-tap.git" tap
+git clone "https://github.com/klarlabs-studio/homebrew-tap.git" tap
 cd tap
 
 # Generate updated formula
 echo "Generating formula..."
 cat > Formula/coverctl.rb << EOF
 # Homebrew formula for Coverctl
-# To install: brew tap felixgeelhaar/tap && brew install coverctl
+# To install: brew tap klarlabs-studio/tap && brew install coverctl
 class Coverctl < Formula
   desc "Declarative, domain-aware coverage enforcement for any language"
   homepage "https://github.com/klarlabs-studio/coverctl"


### PR DESCRIPTION
Tap moved to the org alongside the repositories. Install is now:
brew install klarlabs-studio/tap/coverctl
