### PR TITLE
ci(lint): drop gosec — security owned by nox

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
-# klarlabs-studio shared Go lint bar (golangci-lint v2). gocritic and gosec are
-# part of the org bar — do not drop them. Repo-specific exclusions go under
-# `exclusions.rules`.
+# klarlabs-studio shared Go lint bar (golangci-lint v2). gocritic is
+# part of the org bar — do not drop it. Code-level security is owned by nox.
+# Repo-specific exclusions go under `exclusions.rules`.
 version: "2"
 
 run:
@@ -18,7 +18,6 @@ linters:
     - unconvert
     - unparam
     - gocritic     # org engineering bar — do not drop
-    - gosec
   settings:
     misspell:
       locale: US
@@ -30,12 +29,6 @@ linters:
         - fmt.Fprint
         - fmt.Fprintf
         - fmt.Fprintln
-  exclusions:
-    rules:
-      # Tests legitimately use math/rand (deterministic fixtures, fuzz
-      # seeds). G404 weak-RNG does not apply to test code.
-      - path: _test\.go
-        linters: [gosec]
 
 formatters:
   enable:

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -112,7 +112,7 @@ func parseGlobalFlags(args []string) (GlobalOptions, string, []string) {
 
 loop:
 	for i := 0; i < len(args); i++ {
-		arg := args[i] // #nosec G602 -- i is bounded by len(args) in the loop condition
+		arg := args[i]
 
 		switch arg {
 		case "-q", "--quiet":
@@ -407,7 +407,7 @@ func writeConfigFile(path string, cfg application.Config, stdout io.Writer, forc
 	if err != nil {
 		return fmt.Errorf("invalid path: %w", err)
 	}
-	file, err := os.Create(cleanPath) // #nosec G304 - path is validated above
+	file, err := os.Create(cleanPath)
 	if err != nil {
 		return err
 	}
@@ -470,7 +470,7 @@ func writeBadgeFile(path string, percent float64, label, style string) error {
 	if err != nil {
 		return fmt.Errorf("invalid path: %w", err)
 	}
-	file, err := os.Create(cleanPath) // #nosec G304 - path is validated above
+	file, err := os.Create(cleanPath)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/cmd_survey.go
+++ b/internal/cli/cmd_survey.go
@@ -135,7 +135,6 @@ func writeSurveyResponse(dataDir, code string) error {
 		return fmt.Errorf("mkdir %s: %w", dataDir, err)
 	}
 	path := filepath.Join(dataDir, "survey.jsonl")
-	// #nosec G304 -- path is dataDir joined with a constant filename
 	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
 	if err != nil {
 		return fmt.Errorf("open %s: %w", path, err)

--- a/internal/infrastructure/annotations/scanner.go
+++ b/internal/infrastructure/annotations/scanner.go
@@ -60,7 +60,7 @@ func (Scanner) Scan(_ context.Context, moduleRoot string, files []string) (map[s
 		if err != nil {
 			continue // Skip invalid paths
 		}
-		f, err := os.Open(cleanPath) // #nosec G304 - path is validated above
+		f, err := os.Open(cleanPath)
 		if err != nil {
 			if os.IsNotExist(err) {
 				continue

--- a/internal/infrastructure/cmdrun/cmdrun.go
+++ b/internal/infrastructure/cmdrun/cmdrun.go
@@ -83,7 +83,7 @@ func (r Runner) Exec(ctx context.Context, dir, binary string, args []string) err
 	)
 	start := time.Now()
 
-	cmd := exec.CommandContext(ctx, binary, args...) // #nosec G204 - binary is a constant per-runner identifier; args are caller-validated
+	cmd := exec.CommandContext(ctx, binary, args...)
 	if dir != "" {
 		cmd.Dir = dir
 	}

--- a/internal/infrastructure/config/loader.go
+++ b/internal/infrastructure/config/loader.go
@@ -162,7 +162,7 @@ func (l Loader) loadWithCycleCheck(path string, visited map[string]struct{}) (ap
 	}
 	visited[absPath] = struct{}{}
 
-	raw, err := os.ReadFile(cleanPath) // #nosec G304 - path is validated above
+	raw, err := os.ReadFile(cleanPath)
 	if err != nil {
 		return application.Config{}, err
 	}

--- a/internal/infrastructure/coverprofile/parser.go
+++ b/internal/infrastructure/coverprofile/parser.go
@@ -73,7 +73,7 @@ func parseProfile(path string) (map[string]map[string]domain.CoverageStat, error
 		return nil, fmt.Errorf("invalid path: %w", err)
 	}
 
-	file, err := os.Open(cleanPath) // #nosec G304 - path is validated above
+	file, err := os.Open(cleanPath)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/infrastructure/gotool/resolver.go
+++ b/internal/infrastructure/gotool/resolver.go
@@ -122,7 +122,7 @@ func (r DomainResolver) ModulePath(ctx context.Context) (string, error) {
 
 func goList(ctx context.Context, dir string, patterns ...string) ([]goPackage, error) {
 	args := append([]string{"list", "-json"}, patterns...)
-	cmd := exec.CommandContext(ctx, "go", args...) // #nosec G204 - patterns from trusted config, not user input
+	cmd := exec.CommandContext(ctx, "go", args...)
 	cmd.Dir = dir
 	out, err := cmd.Output()
 	if err != nil {

--- a/internal/infrastructure/history/lock_unix.go
+++ b/internal/infrastructure/history/lock_unix.go
@@ -32,7 +32,6 @@ func (s *FileStore) acquireLock() (*fileLock, error) {
 		return nil, err
 	}
 
-	// #nosec G304 -- Path is derived from trusted config
 	file, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
 	if err != nil {
 		return nil, err

--- a/internal/infrastructure/history/lock_windows.go
+++ b/internal/infrastructure/history/lock_windows.go
@@ -23,7 +23,6 @@ func (s *FileStore) acquireLock() (*fileLock, error) {
 		return nil, err
 	}
 
-	// #nosec G304 -- Path is derived from trusted config
 	file, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
 	if err != nil {
 		return nil, err

--- a/internal/infrastructure/parsers/cobertura/parser.go
+++ b/internal/infrastructure/parsers/cobertura/parser.go
@@ -66,7 +66,7 @@ func (p *Parser) Parse(path string) (map[string]domain.CoverageStat, error) {
 		return nil, fmt.Errorf("invalid path: %w", err)
 	}
 
-	file, err := os.Open(cleanPath) // #nosec G304 - path is validated above
+	file, err := os.Open(cleanPath)
 	if err != nil {
 		return nil, fmt.Errorf("open cobertura file: %w", err)
 	}

--- a/internal/infrastructure/parsers/detector/detector.go
+++ b/internal/infrastructure/parsers/detector/detector.go
@@ -151,7 +151,7 @@ func isLCOV(content []byte) bool {
 
 // readHead reads the first n bytes of a file.
 func readHead(path string, n int) ([]byte, error) {
-	file, err := os.Open(path) // #nosec G304 - path is validated by caller
+	file, err := os.Open(path)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/infrastructure/parsers/jacoco/parser.go
+++ b/internal/infrastructure/parsers/jacoco/parser.go
@@ -70,7 +70,7 @@ func (p *Parser) Parse(path string) (map[string]domain.CoverageStat, error) {
 		return nil, fmt.Errorf("invalid path: %w", err)
 	}
 
-	file, err := os.Open(cleanPath) // #nosec G304 - path is validated above
+	file, err := os.Open(cleanPath)
 	if err != nil {
 		return nil, fmt.Errorf("open jacoco file: %w", err)
 	}

--- a/internal/infrastructure/parsers/lcov/parser.go
+++ b/internal/infrastructure/parsers/lcov/parser.go
@@ -40,7 +40,7 @@ func (p *Parser) Parse(path string) (map[string]domain.CoverageStat, error) {
 		return nil, fmt.Errorf("invalid path: %w", err)
 	}
 
-	file, err := os.Open(cleanPath) // #nosec G304 - path is validated above
+	file, err := os.Open(cleanPath)
 	if err != nil {
 		return nil, fmt.Errorf("open lcov file: %w", err)
 	}

--- a/internal/infrastructure/runners/csharp.go
+++ b/internal/infrastructure/runners/csharp.go
@@ -167,14 +167,12 @@ func runCSharpCommand(ctx context.Context, dir string, cmd string, args []string
 
 // copyFile copies the contents of src to dst, creating dst if it does not exist.
 func copyFile(src, dst string) error {
-	// #nosec G304 -- src path is constructed from filepath.Glob result within project directory
 	in, err := os.Open(src)
 	if err != nil {
 		return err
 	}
 	defer func() { _ = in.Close() }()
 
-	// #nosec G304 -- dst path is the canonical profile path constructed from project directory
 	out, err := os.Create(dst)
 	if err != nil {
 		return err

--- a/internal/infrastructure/runners/dart.go
+++ b/internal/infrastructure/runners/dart.go
@@ -96,7 +96,6 @@ func (r *DartRunner) RunIntegration(ctx context.Context, opts application.Integr
 // detectTool determines whether to use dart or flutter based on pubspec.yaml content.
 func (r *DartRunner) detectTool(projectDir string) string {
 	pubspecPath := filepath.Join(projectDir, "pubspec.yaml")
-	// #nosec G304 -- pubspecPath is derived from the project directory under analysis
 	data, err := os.ReadFile(pubspecPath)
 	if err != nil {
 		return "dart"

--- a/internal/infrastructure/runners/nodejs.go
+++ b/internal/infrastructure/runners/nodejs.go
@@ -101,7 +101,6 @@ func (r *NodeRunner) RunIntegration(ctx context.Context, opts application.Integr
 func (r *NodeRunner) detectCoverageTool(projectDir string) string {
 	// Check package.json for hints
 	pkgPath := filepath.Join(projectDir, "package.json")
-	// #nosec G304 -- Path is constructed from trusted project directory
 	if data, err := os.ReadFile(pkgPath); err == nil {
 		var pkg struct {
 			Scripts      map[string]string `json:"scripts"`

--- a/internal/infrastructure/runners/shell.go
+++ b/internal/infrastructure/runners/shell.go
@@ -310,7 +310,6 @@ func (r *ShellRunner) collectCoberturaProfile(coverageDir, profile string) error
 	}
 
 	// Read the source file and write to the canonical profile path
-	// #nosec G304 -- src is resolved from filepath.Glob within the project directory
 	data, err := os.ReadFile(src)
 	if err != nil {
 		return fmt.Errorf("reading coverage profile: %w", err)

--- a/internal/infrastructure/runners/swift.go
+++ b/internal/infrastructure/runners/swift.go
@@ -113,7 +113,6 @@ func (r *SwiftRunner) Run(ctx context.Context, opts application.RunOptions) (str
 	}
 
 	// Write LCOV output to the profile path
-	// #nosec G306 -- Coverage profile does not require restrictive permissions
 	if err := os.WriteFile(profile, output, 0o644); err != nil {
 		return "", fmt.Errorf("swift coverage failed: %w", err)
 	}
@@ -174,7 +173,6 @@ func runSwiftCommand(ctx context.Context, dir string, tool string, args []string
 
 // runSwiftCommandOutput executes a Swift or Xcode toolchain command and returns stdout.
 func runSwiftCommandOutput(ctx context.Context, dir string, tool string, args []string) ([]byte, error) {
-	// #nosec G204 -- Tool is validated by caller (swift, xcrun)
 	cmd := exec.CommandContext(ctx, tool, args...)
 	if dir != "" {
 		cmd.Dir = dir

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -409,7 +409,7 @@ func (s *Server) handleInit(ctx context.Context, input InitInput) (map[string]an
 	}
 
 	// Write the config file
-	file, err := os.Create(cleanPath) // #nosec G304 - path is validated above
+	file, err := os.Create(cleanPath)
 	if err != nil {
 		return errorResponse(
 			OpCodeFileWrite,
@@ -862,7 +862,7 @@ func detectPRContextMCP(provider application.PRProvider, owner, repo string, prN
 		// GitLab can also auto-detect MR number
 		if prNumber == 0 {
 			if mrIID := os.Getenv("CI_MERGE_REQUEST_IID"); mrIID != "" {
-				_, _ = fmt.Sscanf(mrIID, "%d", &prNumber) // #nosec G104 - parse failure leaves prNumber as 0, which is acceptable
+				_, _ = fmt.Sscanf(mrIID, "%d", &prNumber)
 			}
 		}
 	}
@@ -878,7 +878,7 @@ func detectPRContextMCP(provider application.PRProvider, owner, repo string, prN
 		// Bitbucket can also auto-detect PR number
 		if prNumber == 0 {
 			if prID := os.Getenv("BITBUCKET_PR_ID"); prID != "" {
-				_, _ = fmt.Sscanf(prID, "%d", &prNumber) // #nosec G104 - parse failure leaves prNumber as 0, which is acceptable
+				_, _ = fmt.Sscanf(prID, "%d", &prNumber)
 			}
 		}
 	}
@@ -939,7 +939,7 @@ func backupConfig(configPath string) (string, error) {
 	}
 
 	// Read original content
-	content, err := os.ReadFile(configPath) // #nosec G304 - path from trusted config
+	content, err := os.ReadFile(configPath)
 	if err != nil {
 		return "", fmt.Errorf("read config: %w", err)
 	}
@@ -961,7 +961,7 @@ func writeConfig(configPath string, cfg application.Config) error {
 		return fmt.Errorf("invalid config path: %w", err)
 	}
 
-	file, err := os.Create(cleanPath) // #nosec G304 - path is validated above
+	file, err := os.Create(cleanPath)
 	if err != nil {
 		return fmt.Errorf("create config: %w", err)
 	}


### PR DESCRIPTION
## Drop gosec — security is owned by nox

The org has standardized on **nox** for security scanning (secrets + IaC + dependency + AI + taint-analysis SAST), replacing gosec at the code-lint layer. The golden config in `klarlabs-studio/.github` (`golangci.reference.yml`) already dropped gosec; this PR brings `coverctl` in line.

### Changes
- **`.golangci.yml`**: removed `gosec` from `linters.enable`, removed the `linters.settings.gosec` block (where present), and pruned gosec from `exclusions.rules` (dropping gosec-only rules entirely, removing the `gosec` token from mixed rules). Everything else — gocritic, the standard set, formatters, repo-specific config — is preserved unchanged.
- **Dead suppressions**: removed 27 now-unused gosec lint directives (`//nolint:gosec` / `// #nosec Gxxx`) that become dead once gosec is gone. For mixed `//nolint:errcheck,gosec` directives, only the `gosec` token was removed; the rest is kept.

### Verification
- `.golangci.yml` parses; no residual gosec references.
- `golangci-lint run ./...` (v2.12.2, the CI-pinned version) and `go build ./...` run locally.
- Removing gosec + its suppressions can only reduce lint findings.

No merge intended — opening for the Lint CI gate to confirm green.