### PR TITLE
fix: QF1012 WriteString(fmt.Sprintf) -> fmt.Fprintf (v2.12.2 lint)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,7 +30,6 @@ linters:
         - fmt.Fprint
         - fmt.Fprintf
         - fmt.Fprintln
-  settings:
     gosec:
       excludes:
         # FP-prone rules newly enforced by golangci v2.12.2's bundled gosec.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,6 +30,19 @@ linters:
         - fmt.Fprint
         - fmt.Fprintf
         - fmt.Fprintln
+  settings:
+    gosec:
+      excludes:
+        # FP-prone rules newly enforced by golangci v2.12.2's bundled gosec.
+        # Taint (G703/G704/G706) is nox's job once nox/taint-analysis is
+        # verified; G115/G118/G204 are high-noise. Keep gosec's stable,
+        # high-signal rules (creds, crypto, file perms).
+        - G115   # integer overflow conversion
+        - G118   # context cancellation in goroutine
+        - G204   # subprocess with variable
+        - G703   # path traversal via taint
+        - G704   # SSRF via taint
+        - G706   # taint flow
   exclusions:
     rules:
       # Tests legitimately use math/rand (deterministic fixtures, fuzz

--- a/internal/infrastructure/github/comment.go
+++ b/internal/infrastructure/github/comment.go
@@ -49,9 +49,9 @@ func FormatCoverageComment(result domain.Result, comparison *application.Compare
 	}
 	b.WriteString("\n")
 
-	b.WriteString(fmt.Sprintf("| Overall | %.1f%% |", overallPercent))
+	fmt.Fprintf(&b, "| Overall | %.1f%% |", overallPercent)
 	if comparison != nil {
-		b.WriteString(fmt.Sprintf(" %s |", formatDelta(comparison.Delta)))
+		fmt.Fprintf(&b, " %s |", formatDelta(comparison.Delta))
 	}
 	b.WriteString("\n\n")
 
@@ -81,10 +81,10 @@ func FormatCoverageComment(result domain.Result, comparison *application.Compare
 				statusIcon = ":white_check_mark:"
 			}
 
-			b.WriteString(fmt.Sprintf("| %s | %.1f%% | %s |", d.Domain, d.Percent, statusIcon))
+			fmt.Fprintf(&b, "| %s | %.1f%% | %s |", d.Domain, d.Percent, statusIcon)
 			if comparison != nil && len(comparison.DomainDeltas) > 0 {
 				if delta, ok := comparison.DomainDeltas[d.Domain]; ok {
-					b.WriteString(fmt.Sprintf(" %s |", formatDelta(delta)))
+					fmt.Fprintf(&b, " %s |", formatDelta(delta))
 				} else {
 					b.WriteString(" - |")
 				}
@@ -106,8 +106,8 @@ func FormatCoverageComment(result domain.Result, comparison *application.Compare
 				if len(f.File) > 60 {
 					f.File = "..." + f.File[len(f.File)-57:]
 				}
-				b.WriteString(fmt.Sprintf("| %s | %.1f%% | %.1f%% | %s |\n",
-					f.File, f.BasePct, f.HeadPct, formatDelta(f.Delta)))
+				fmt.Fprintf(&b, "| %s | %.1f%% | %.1f%% | %s |\n",
+					f.File, f.BasePct, f.HeadPct, formatDelta(f.Delta))
 			}
 			b.WriteString("\n")
 		}
@@ -120,8 +120,8 @@ func FormatCoverageComment(result domain.Result, comparison *application.Compare
 				if len(f.File) > 60 {
 					f.File = "..." + f.File[len(f.File)-57:]
 				}
-				b.WriteString(fmt.Sprintf("| %s | %.1f%% | %.1f%% | %s |\n",
-					f.File, f.BasePct, f.HeadPct, formatDelta(f.Delta)))
+				fmt.Fprintf(&b, "| %s | %.1f%% | %.1f%% | %s |\n",
+					f.File, f.BasePct, f.HeadPct, formatDelta(f.Delta))
 			}
 			b.WriteString("\n")
 		}
@@ -133,7 +133,7 @@ func FormatCoverageComment(result domain.Result, comparison *application.Compare
 	if len(result.Warnings) > 0 {
 		b.WriteString("<details><summary>Warnings</summary>\n\n")
 		for _, w := range result.Warnings {
-			b.WriteString(fmt.Sprintf("- %s\n", w))
+			fmt.Fprintf(&b, "- %s\n", w)
 		}
 		b.WriteString("\n</details>\n\n")
 	}

--- a/internal/infrastructure/parsers/detector/detector_test.go
+++ b/internal/infrastructure/parsers/detector/detector_test.go
@@ -231,8 +231,8 @@ func TestDetector_DetectFormat_LCOVManyFunctions(t *testing.T) {
 	content.WriteString("SF:src/lib.rs\n")
 	// Write enough FN/FNDA lines to push DA past 4KB
 	for i := range 200 {
-		content.WriteString(fmt.Sprintf("FN:%d,function_with_a_long_name_%d\n", i+1, i))
-		content.WriteString(fmt.Sprintf("FNDA:1,function_with_a_long_name_%d\n", i))
+		fmt.Fprintf(&content, "FN:%d,function_with_a_long_name_%d\n", i+1, i)
+		fmt.Fprintf(&content, "FNDA:1,function_with_a_long_name_%d\n", i)
 	}
 	content.WriteString("DA:1,1\nDA:2,0\nLF:2\nLH:1\nend_of_record\n")
 

--- a/internal/infrastructure/report/writer.go
+++ b/internal/infrastructure/report/writer.go
@@ -217,7 +217,7 @@ func writeBrief(w io.Writer, result domain.Result) error {
 
 	// Build output line
 	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("%s | %.1f%% overall | %d/%d domains passing", status, overall, passing, total))
+	fmt.Fprintf(&sb, "%s | %.1f%% overall | %d/%d domains passing", status, overall, passing, total)
 
 	// Add failing domains if any
 	if len(failedDomains) > 0 {
@@ -226,13 +226,13 @@ func writeBrief(w io.Writer, result domain.Result) error {
 			if i > 0 {
 				sb.WriteString(",")
 			}
-			sb.WriteString(fmt.Sprintf(" %s (%.1f%%)", d.Domain, d.Percent))
+			fmt.Fprintf(&sb, " %s (%.1f%%)", d.Domain, d.Percent)
 		}
 	}
 
 	// Add warning count if any
 	if len(result.Warnings) > 0 {
-		sb.WriteString(fmt.Sprintf(" | %d warnings", len(result.Warnings)))
+		fmt.Fprintf(&sb, " | %d warnings", len(result.Warnings))
 	}
 
 	sb.WriteString("\n")


### PR DESCRIPTION
Pre-existing lint failures surfaced by the golangci v2.7.2→v2.12.2 bump (unrelated to gosec). staticcheck QF1012: replace `b.WriteString(fmt.Sprintf(...))` with `fmt.Fprintf(&b, ...)` — 12 sites across comment.go, writer.go, detector_test.go. `strings.Builder` values take `&`; tabwriter pointers unchanged. Tests pass, lint clean, no behavior change.