### PR TITLE
test: activate nox taint plugin (plugins.required)

### DIFF
--- a/.nox.yaml
+++ b/.nox.yaml
@@ -24,3 +24,10 @@ scan:
     # Generated artifacts.
     - "nox-out/"
     - "release-artifacts/"
+
+# Activate nox's code-level taint SAST (source-to-sink): SSRF, injection,
+# path traversal. nox scan auto-installs + runs required plugins (cosign
+# verifies the signed plugin to community trust in CI).
+plugins:
+  required:
+    - nox/taint-analysis


### PR DESCRIPTION
Validation: declares nox/taint-analysis in .nox.yaml plugins.required so nox scan runs source-to-sink taint SAST. Checking TAINT-* findings appear in CI.