### PR TITLE
fix(gate): close fail-open paths in coverage evaluation

### DIFF
--- a/internal/application/extra_gates_test.go
+++ b/internal/application/extra_gates_test.go
@@ -1,0 +1,78 @@
+package application
+
+import (
+	"errors"
+	"testing"
+
+	"go.klarlabs.de/coverctl/internal/domain"
+)
+
+// fakeHistoryStore is a minimal HistoryStore for exercising the ratchet gate.
+type fakeHistoryStore struct {
+	hist    domain.History
+	loadErr error
+}
+
+func (f *fakeHistoryStore) Load() (domain.History, error)    { return f.hist, f.loadErr }
+func (f *fakeHistoryStore) Save(domain.History) error        { return nil }
+func (f *fakeHistoryStore) Append(domain.HistoryEntry) error { return nil }
+
+// resultAt builds a Result whose OverallPercent is the given percentage.
+func resultAt(percent float64) domain.Result {
+	return domain.Result{
+		Passed: true,
+		Domains: []domain.DomainResult{
+			{Domain: "core", Covered: int(percent * 10), Total: 1000},
+		},
+	}
+}
+
+func ptr(f float64) *float64 { return &f }
+
+func TestEnforceExtraGates_FailUnder(t *testing.T) {
+	svc := &Service{}
+	// 60% overall, floor of 90 → violation.
+	err := svc.EnforceExtraGates(resultAt(60), CheckOptions{FailUnder: ptr(90)})
+	if err == nil {
+		t.Fatal("expected fail-under violation, got nil")
+	}
+	// 95% overall, floor of 90 → ok.
+	if err := svc.EnforceExtraGates(resultAt(95), CheckOptions{FailUnder: ptr(90)}); err != nil {
+		t.Fatalf("expected no violation at 95%% vs 90 floor, got %v", err)
+	}
+}
+
+func TestEnforceExtraGates_RatchetRegression(t *testing.T) {
+	svc := &Service{}
+	store := &fakeHistoryStore{hist: domain.History{Entries: []domain.HistoryEntry{{Overall: 95}}}}
+	// Current 60% < previous 95% → regression.
+	err := svc.EnforceExtraGates(resultAt(60), CheckOptions{Ratchet: true, HistoryStore: store})
+	if err == nil {
+		t.Fatal("expected ratchet regression violation, got nil")
+	}
+	// Current 95% == previous 95% → ok (no decrease).
+	if err := svc.EnforceExtraGates(resultAt(95), CheckOptions{Ratchet: true, HistoryStore: store}); err != nil {
+		t.Fatalf("expected no violation when coverage holds, got %v", err)
+	}
+}
+
+// TestEnforceExtraGates_RatchetLoadErrorFailsClosed ensures a corrupt/unreadable
+// baseline does not silently pass the ratchet gate.
+func TestEnforceExtraGates_RatchetLoadErrorFailsClosed(t *testing.T) {
+	svc := &Service{}
+	store := &fakeHistoryStore{loadErr: errors.New("corrupt history file")}
+	err := svc.EnforceExtraGates(resultAt(95), CheckOptions{Ratchet: true, HistoryStore: store})
+	if err == nil {
+		t.Fatal("expected ratchet to fail closed on a history-load error, got nil")
+	}
+}
+
+// TestEnforceExtraGates_RatchetNoBaselinePasses documents that a first run with
+// no recorded history passes (there is nothing to regress from).
+func TestEnforceExtraGates_RatchetNoBaselinePasses(t *testing.T) {
+	svc := &Service{}
+	store := &fakeHistoryStore{hist: domain.History{}}
+	if err := svc.EnforceExtraGates(resultAt(50), CheckOptions{Ratchet: true, HistoryStore: store}); err != nil {
+		t.Fatalf("expected no violation with an empty baseline, got %v", err)
+	}
+}

--- a/internal/application/service.go
+++ b/internal/application/service.go
@@ -301,7 +301,29 @@ func (s *Service) Check(ctx context.Context, opts CheckOptions) error {
 		return err
 	}
 
-	// Check fail-under threshold if specified
+	// Enforce the overall --fail-under floor and the --ratchet no-regression
+	// gate. This is shared with the MCP surface (see EnforceExtraGates) so both
+	// entry points honor these flags identically.
+	if err := s.EnforceExtraGates(result, opts); err != nil {
+		return err
+	}
+
+	if !result.Passed {
+		return fmt.Errorf("policy violation")
+	}
+	return nil
+}
+
+// EnforceExtraGates checks the overall --fail-under floor and the --ratchet
+// no-regression gate against an already-computed result. It returns a
+// descriptive error if either gate is violated, or nil otherwise.
+//
+// These gates are NOT part of the per-domain result.Passed value, so every
+// caller (CLI and MCP alike) must run them explicitly. Under --ratchet a
+// failure to load the coverage history is treated as a violation (fail
+// closed) rather than being silently ignored — an unreadable baseline must
+// not let a regression through.
+func (s *Service) EnforceExtraGates(result domain.Result, opts CheckOptions) error {
 	if opts.FailUnder != nil {
 		overallPercent := result.OverallPercent()
 		if overallPercent < *opts.FailUnder {
@@ -309,20 +331,21 @@ func (s *Service) Check(ctx context.Context, opts CheckOptions) error {
 		}
 	}
 
-	// Check ratchet: coverage must not decrease from previous value
-	if opts.Ratchet && opts.HistoryStore != nil {
+	if opts.Ratchet {
+		if opts.HistoryStore == nil {
+			return fmt.Errorf("ratchet: no coverage history store configured")
+		}
 		hist, err := opts.HistoryStore.Load()
-		if err == nil && len(hist.Entries) > 0 {
+		if err != nil {
+			return fmt.Errorf("ratchet: cannot load coverage history: %w", err)
+		}
+		if len(hist.Entries) > 0 {
 			previousPercent := hist.Entries[len(hist.Entries)-1].Overall
 			currentPercent := result.OverallPercent()
 			if currentPercent < previousPercent {
 				return fmt.Errorf("coverage decreased from %.1f%% to %.1f%% (--ratchet prevents regression)", previousPercent, currentPercent)
 			}
 		}
-	}
-
-	if !result.Passed {
-		return fmt.Errorf("policy violation")
 	}
 	return nil
 }

--- a/internal/domain/policy.go
+++ b/internal/domain/policy.go
@@ -312,12 +312,16 @@ func Evaluate(policy Policy, coverage map[string]CoverageStat) Result {
 		if d.Min != nil {
 			required = *d.Min
 		}
-		percent := Round1(stat.Percent())
+		// Compare the raw percentage against the threshold so that a value just
+		// under the bound (e.g. 79.95%) cannot round up to 80.0 and pass an 80%
+		// gate. The rounded value is used only for display/reporting.
+		rawPercent := stat.Percent()
+		percent := Round1(rawPercent)
 		status := StatusPass
-		if percent < required {
+		if rawPercent < required {
 			status = StatusFail
 			passed = false
-		} else if d.Warn != nil && percent < *d.Warn {
+		} else if d.Warn != nil && rawPercent < *d.Warn {
 			// Above min but below warn threshold
 			status = StatusWarn
 		}

--- a/internal/domain/policy_aggregate.go
+++ b/internal/domain/policy_aggregate.go
@@ -134,10 +134,13 @@ func (p *PolicyAggregate) Evaluate(coverage map[string]CoverageStat) EvaluationR
 
 	for _, spec := range p.domains {
 		stat := coverage[spec.Name.String()]
-		percent := NewPercentage(stat.PercentRounded())
+		// Compare the raw percentage against thresholds; the rounded Percentage
+		// is retained only for display (see determineStatus).
+		rawPercent := stat.Percent()
+		percent := NewPercentage(rawPercent)
 		required := spec.MinValue
 
-		status := p.determineStatus(percent, spec)
+		status := p.determineStatus(rawPercent, spec)
 		if status == StatusFail {
 			passed = false
 			// Record threshold violation event
@@ -177,12 +180,14 @@ func (p *PolicyAggregate) Evaluate(coverage map[string]CoverageStat) EvaluationR
 	return result
 }
 
-// determineStatus determines the coverage status for a domain.
-func (p *PolicyAggregate) determineStatus(percent Percentage, spec DomainSpec) Status {
-	if !percent.MeetsThreshold(spec.MinValue) {
+// determineStatus determines the coverage status for a domain from the raw
+// (unrounded) percentage, so a value just below a threshold cannot round up
+// and pass.
+func (p *PolicyAggregate) determineStatus(rawPercent float64, spec DomainSpec) Status {
+	if !spec.MinValue.IsMet(rawPercent) {
 		return StatusFail
 	}
-	if spec.WarnValue != nil && !percent.MeetsThreshold(*spec.WarnValue) {
+	if spec.WarnValue != nil && !spec.WarnValue.IsMet(rawPercent) {
 		return StatusWarn
 	}
 	return StatusPass

--- a/internal/domain/policy_test.go
+++ b/internal/domain/policy_test.go
@@ -28,6 +28,53 @@ func TestEvaluatePolicy(t *testing.T) {
 	}
 }
 
+// TestEvaluateRoundingDoesNotPassSubThreshold ensures the threshold comparison
+// uses the raw percentage, not the display-rounded one: 79.95% rounds to 80.0
+// for display but must still FAIL an 80% gate.
+func TestEvaluateRoundingDoesNotPassSubThreshold(t *testing.T) {
+	policy := Policy{
+		DefaultMin: 80,
+		Domains:    []Domain{{Name: "core"}},
+	}
+	// 7995/10000 = 79.95% (raw) which Round1 rounds up to 80.0.
+	coverage := map[string]CoverageStat{"core": {Covered: 7995, Total: 10000}}
+
+	result := Evaluate(policy, coverage)
+	if result.Passed {
+		t.Fatalf("expected 79.95%% to fail an 80%% gate, but it passed")
+	}
+	if got := result.Domains[0].Status; got != StatusFail {
+		t.Fatalf("expected core to FAIL, got %s", got)
+	}
+	// Display value is still the rounded 80.0.
+	if got := result.Domains[0].Percent; got != 80.0 {
+		t.Fatalf("expected displayed percent 80.0, got %v", got)
+	}
+
+	// Exactly 80.0 must still pass.
+	pass := Evaluate(policy, map[string]CoverageStat{"core": {Covered: 8000, Total: 10000}})
+	if !pass.Passed {
+		t.Fatalf("expected exactly 80.0%% to pass an 80%% gate")
+	}
+}
+
+// TestPolicyAggregateRoundingDoesNotPassSubThreshold mirrors the above for the
+// aggregate evaluation path.
+func TestPolicyAggregateRoundingDoesNotPassSubThreshold(t *testing.T) {
+	policy := Policy{DefaultMin: 80, Domains: []Domain{{Name: "core"}}}
+	agg, err := NewPolicyAggregate(policy)
+	if err != nil {
+		t.Fatalf("new aggregate: %v", err)
+	}
+	res := agg.Evaluate(map[string]CoverageStat{"core": {Covered: 7995, Total: 10000}})
+	if res.Passed {
+		t.Fatalf("expected aggregate 79.95%% to fail an 80%% gate")
+	}
+	if res.DomainResults[0].Status != StatusFail {
+		t.Fatalf("expected core to FAIL, got %s", res.DomainResults[0].Status)
+	}
+}
+
 func TestCoveragePercent(t *testing.T) {
 	stat := CoverageStat{Covered: 1, Total: 3}
 	if got := stat.Percent(); got < 33.3 || got > 33.4 {

--- a/internal/eval/harness_test.go
+++ b/internal/eval/harness_test.go
@@ -20,6 +20,9 @@ type stubService struct{}
 func (stubService) CheckResult(context.Context, application.CheckOptions) (domain.Result, error) {
 	return domain.Result{}, nil
 }
+func (stubService) EnforceExtraGates(domain.Result, application.CheckOptions) error {
+	return nil
+}
 func (stubService) ReportResult(context.Context, application.ReportOptions) (domain.Result, error) {
 	return domain.Result{}, nil
 }

--- a/internal/infrastructure/coverprofile/parser.go
+++ b/internal/infrastructure/coverprofile/parser.go
@@ -130,9 +130,19 @@ func parseLine(line string) (string, string, int, int, error) {
 	if err != nil {
 		return "", "", 0, 0, fmt.Errorf("invalid statement count")
 	}
+	if stmtCount < 0 {
+		// A negative statement count is never emitted by `go tool cover` and,
+		// if summed into a domain's Total, shrinks the denominator below the
+		// covered count — inflating coverage above 100% and passing the gate.
+		// Reject it so a crafted/corrupt profile fails closed.
+		return "", "", 0, 0, fmt.Errorf("invalid statement count: negative value %d", stmtCount)
+	}
 	count, err := strconv.ParseInt(countPart, 10, 64)
 	if err != nil {
 		return "", "", 0, 0, fmt.Errorf("invalid count")
+	}
+	if count < 0 {
+		return "", "", 0, 0, fmt.Errorf("invalid count: negative value %d", count)
 	}
 
 	covered := 0

--- a/internal/infrastructure/coverprofile/parser_test.go
+++ b/internal/infrastructure/coverprofile/parser_test.go
@@ -69,6 +69,36 @@ func TestParseLineInvalidNumber(t *testing.T) {
 	}
 }
 
+// TestParseLineRejectsNegativeCounts guards against a crafted/corrupt profile
+// with a negative statement count. Summed into a domain's Total, a negative
+// count shrinks the denominator below the covered count, inflating coverage
+// above 100% and passing the gate. The parser must fail closed instead.
+func TestParseLineRejectsNegativeCounts(t *testing.T) {
+	if _, _, _, _, err := parseLine("foo.go:1.1,2.2 -5 0"); err == nil {
+		t.Fatalf("expected error for negative statement count")
+	}
+	if _, _, _, _, err := parseLine("foo.go:1.1,2.2 5 -1"); err == nil {
+		t.Fatalf("expected error for negative execution count")
+	}
+}
+
+// TestParseRejectsNegativeCountProfile verifies the guard at the profile level:
+// a real file plus one negative-count line must error rather than silently
+// inflating the file's coverage.
+func TestParseRejectsNegativeCountProfile(t *testing.T) {
+	content := "mode: atomic\n" +
+		"internal/core/foo.go:1.2,3.4 80 80\n" +
+		"internal/core/foo.go:5.6,7.8 -30 0\n"
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "coverage.out")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, err := (Parser{}).Parse(path); err == nil {
+		t.Fatalf("expected error for profile containing a negative statement count")
+	}
+}
+
 func TestParseRepeatedLineKeepsMax(t *testing.T) {
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "coverage.out")

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -223,6 +223,18 @@ func (s *Server) handleCheck(ctx context.Context, input CheckInput) (map[string]
 		return classified, nil
 	}
 
+	// Enforce the overall --fail-under floor and the --ratchet no-regression
+	// gate. CheckResult computes only the per-domain result.Passed, so without
+	// this an agent-supplied failUnder/ratchet is silently a no-op on the MCP
+	// surface (the CLI enforces them in Service.Check). Fold any violation into
+	// passed + warnings so the agent sees the regression it asked us to block.
+	if err == nil {
+		if gateErr := s.svc.EnforceExtraGates(result, opts); gateErr != nil {
+			result.Passed = false
+			result.Warnings = append(result.Warnings, gateErr.Error())
+		}
+	}
+
 	v := resolveVerbosity(input.Verbosity)
 	domains, domainCursor := applyDomainBudget(result.Domains, v)
 	files, fileCursor := applyFileBudget(result.Files, v)

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -18,31 +18,38 @@ var _ Service = (*application.Service)(nil)
 
 // mockService implements the Service interface for testing.
 type mockService struct {
-	checkResult   domain.Result
-	checkErr      error
-	checkOpts     application.CheckOptions // Captured options from last call
-	reportResult  domain.Result
-	reportErr     error
-	recordResult  application.RecordResult
-	recordErr     error
-	recordOpts    application.RecordOptions
-	debtResult    application.DebtResult
-	debtErr       error
-	trendResult   application.TrendResult
-	trendErr      error
-	suggestResult application.SuggestResult
-	suggestErr    error
-	badgeResult   application.BadgeResult
-	badgeErr      error
-	compareResult application.CompareResult
-	compareErr    error
-	detectResult  application.Config
-	detectErr     error
+	checkResult      domain.Result
+	checkErr         error
+	checkOpts        application.CheckOptions // Captured options from last call
+	enforceGatesErr  error                    // Returned by EnforceExtraGates
+	enforceGatesOpts application.CheckOptions // Captured options from last EnforceExtraGates call
+	reportResult     domain.Result
+	reportErr        error
+	recordResult     application.RecordResult
+	recordErr        error
+	recordOpts       application.RecordOptions
+	debtResult       application.DebtResult
+	debtErr          error
+	trendResult      application.TrendResult
+	trendErr         error
+	suggestResult    application.SuggestResult
+	suggestErr       error
+	badgeResult      application.BadgeResult
+	badgeErr         error
+	compareResult    application.CompareResult
+	compareErr       error
+	detectResult     application.Config
+	detectErr        error
 }
 
 func (m *mockService) CheckResult(ctx context.Context, opts application.CheckOptions) (domain.Result, error) {
 	m.checkOpts = opts // Capture the options for verification
 	return m.checkResult, m.checkErr
+}
+
+func (m *mockService) EnforceExtraGates(result domain.Result, opts application.CheckOptions) error {
+	m.enforceGatesOpts = opts
+	return m.enforceGatesErr
 }
 
 func (m *mockService) ReportResult(ctx context.Context, opts application.ReportOptions) (domain.Result, error) {
@@ -330,6 +337,45 @@ func TestHandleCheck(t *testing.T) {
 	}
 	if summary, ok := output["summary"].(string); !ok || summary == "" {
 		t.Error("expected non-empty summary")
+	}
+}
+
+// TestHandleCheck_EnforcesExtraGates verifies that a --fail-under/--ratchet
+// violation reported by EnforceExtraGates flips the MCP response to passed=false
+// and surfaces the reason, even when the per-domain result passed. Without this
+// wiring, failUnder/ratchet were silently a no-op on the agent surface.
+func TestHandleCheck_EnforcesExtraGates(t *testing.T) {
+	svc := &mockService{
+		checkResult: domain.Result{
+			Passed: true,
+			Domains: []domain.DomainResult{
+				{Domain: "core", Status: domain.StatusPass, Covered: 60, Total: 100},
+			},
+		},
+		enforceGatesErr: errors.New("coverage decreased from 95.0% to 60.0% (--ratchet prevents regression)"),
+	}
+	server := New(svc, DefaultConfig(), "test")
+
+	output, err := server.handleCheck(context.Background(), CheckInput{Ratchet: true})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if passed, ok := output["passed"].(bool); !ok || passed {
+		t.Fatalf("expected passed=false after a gate violation, got %v", output["passed"])
+	}
+	// The options must actually be forwarded to the enforcement call.
+	if !svc.enforceGatesOpts.Ratchet {
+		t.Error("expected EnforceExtraGates to receive Ratchet=true")
+	}
+	warnings, _ := output["warnings"].([]string)
+	found := false
+	for _, w := range warnings {
+		if w == "coverage decreased from 95.0% to 60.0% (--ratchet prevents regression)" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected the ratchet reason in warnings, got %v", warnings)
 	}
 }
 

--- a/internal/mcp/types.go
+++ b/internal/mcp/types.go
@@ -23,6 +23,10 @@ import (
 type Service interface {
 	// Tools (actions that may have side effects)
 	CheckResult(ctx context.Context, opts application.CheckOptions) (domain.Result, error)
+	// EnforceExtraGates applies the overall --fail-under floor and --ratchet
+	// no-regression gate to a CheckResult (these are not part of per-domain
+	// result.Passed and must be applied on the MCP surface too).
+	EnforceExtraGates(result domain.Result, opts application.CheckOptions) error
 	ReportResult(ctx context.Context, opts application.ReportOptions) (domain.Result, error)
 	Record(ctx context.Context, opts application.RecordOptions, store application.HistoryStore) error
 	PRComment(ctx context.Context, opts application.PRCommentOptions) (application.PRCommentResult, error)


### PR DESCRIPTION
## Summary

First batch of a deep-review-and-harden pass on coverctl. This PR closes the
**crown-jewel bug class for a coverage-governance tool: the gate reporting PASS
when it should FAIL.** A 6-agent review surfaced four such fail-open paths, all
verified in the code and now fixed with tests.

## Fail-open paths closed

| Severity | Path | Fix |
|---|---|---|
| HIGH | MCP `check` tool **ignored `failUnder`/`ratchet`** — enforcement lived only in `Service.Check` (CLI), but the MCP handler calls `CheckResult` directly, so an agent asking for `ratchet:true` / `failUnder:90` got `passed:true` on a regression | Extracted `Service.EnforceExtraGates`; called from **both** the CLI (`Check`) and the MCP handler (`handleCheck`), folding any violation into `passed=false` + a warning |
| HIGH | **Negative statement count** in a coverage profile underflowed a domain's denominator (`Total` < `Covered` ⇒ >100% ⇒ passes) — reachable via `--from-profile`, merge profiles, and the MCP `profile` arg | Reject negative statement/execution counts in the coverprofile parser (fail closed) |
| MED | `Round1()` applied **before** the threshold compare → 79.95% rounded up to 80.0 and passed an 80% gate | Compare the **raw** percentage; round only for display. Fixed in both the legacy `Evaluate` and the `PolicyAggregate` path |
| MED | `--ratchet` **swallowed a history-load error** and passed (corrupt/unreadable baseline ⇒ no gate) | `EnforceExtraGates` fails closed when the baseline can't be read |

## Tests

- `parser`: negative statement/execution counts rejected (line-level + profile-level).
- `domain`: 79.95% FAILs an 80% gate while displaying 80.0; exactly 80.0 still passes — both eval paths.
- `application`: `EnforceExtraGates` fail-under, ratchet regression, ratchet load-error-fails-closed, empty-baseline-passes.
- `mcp`: `handleCheck` flips `passed=false` + surfaces the reason when a gate is violated (the wiring that was previously a no-op).

Full suite green under `go test -race ./...`, `gofmt`, `go vet`, and `golangci-lint run ./...` (0 issues).

## Notes

- The rounding change is a deliberate fail-closed tightening: the ~0.05pp boundary band that used to pass will now fail. Exact-threshold coverage (e.g. 80.0% for an 80 gate) is unaffected.
- Remaining review findings (diff-filename quotePath, path-traversal batch, glob `**`, MCP panic-recovery / suggest-writeConfig gating, VCS defense-in-depth, robustness LOWs) will follow as separate scoped PRs.

https://claude.ai/code/session_01QKTcmXFTKoTQr7mB3HCuHZ
