### PR TITLE
fix(security): enforce path containment in annotation scan and config extends

### DIFF
--- a/internal/infrastructure/annotations/scanner.go
+++ b/internal/infrastructure/annotations/scanner.go
@@ -52,15 +52,19 @@ func (Scanner) Scan(_ context.Context, moduleRoot string, files []string) (map[s
 		if !supportedExtensions[filepath.Ext(file)] {
 			continue
 		}
-		path := file
-		if moduleRoot != "" {
-			path = filepath.Join(moduleRoot, filepath.FromSlash(file))
+		// Containment requires a known module root. Without one we cannot prove a
+		// coverage-map-derived path stays inside the module, so skip the read
+		// rather than freely join an attacker-influenced ../ path.
+		if moduleRoot == "" {
+			continue
 		}
-		cleanPath, err := pathutil.ValidatePath(path)
+		// The file path originates from a (semi-trusted) coverage report; scope it
+		// to moduleRoot so a `..` or symlink entry cannot escape the module tree.
+		cleanPath, err := pathutil.ValidateScopedPath(filepath.FromSlash(file), moduleRoot)
 		if err != nil {
-			continue // Skip invalid paths
+			continue // Skip paths that escape the module root or are otherwise invalid
 		}
-		f, err := os.Open(cleanPath) // #nosec G304 - path is validated above
+		f, err := os.Open(cleanPath) // #nosec G304 - path is scoped to moduleRoot above
 		if err != nil {
 			if os.IsNotExist(err) {
 				continue

--- a/internal/infrastructure/annotations/scanner_test.go
+++ b/internal/infrastructure/annotations/scanner_test.go
@@ -105,3 +105,39 @@ func TestScannerIgnoresMissingFile(t *testing.T) {
 		t.Fatalf("expected missing file to be ignored: %v", err)
 	}
 }
+
+func TestScannerSkipsPathEscapingModuleRoot(t *testing.T) {
+	root := t.TempDir()
+	moduleRoot := filepath.Join(root, "module")
+	if err := os.MkdirAll(moduleRoot, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// A secret file OUTSIDE the module root that carries an annotation. A
+	// coverage-map-derived `../secret.go` entry must not read it.
+	outside := filepath.Join(root, "secret.go")
+	if err := os.WriteFile(outside, []byte("// coverctl:domain=secret\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	out, err := (Scanner{}).Scan(context.Background(), moduleRoot, []string{"../secret.go"})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if len(out) != 0 {
+		t.Fatalf("expected escaping path to be skipped, got %v", out)
+	}
+	if _, ok := out["../secret.go"]; ok {
+		t.Fatal("escaping path must not be read")
+	}
+}
+
+func TestScannerSkipsWhenModuleRootEmpty(t *testing.T) {
+	// Without a module root, containment cannot be enforced, so reads are skipped
+	// rather than joining an attacker-influenced path freely.
+	out, err := (Scanner{}).Scan(context.Background(), "", []string{"main.go", "../../etc/passwd.go"})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if len(out) != 0 {
+		t.Fatalf("expected no annotations without a module root, got %v", out)
+	}
+}

--- a/internal/infrastructure/config/loader.go
+++ b/internal/infrastructure/config/loader.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 
@@ -181,11 +182,12 @@ func (l Loader) loadWithCycleCheck(path string, visited map[string]struct{}) (ap
 	// Handle config inheritance
 	var parentCfg application.Config
 	if cfg.Extends != "" {
-		// Resolve parent path relative to current config's directory
+		// Resolve parent path relative to current config's directory, enforcing
+		// containment so `extends` cannot be turned into an arbitrary-file read.
 		configDir := filepath.Dir(absPath)
-		parentPath := cfg.Extends
-		if !filepath.IsAbs(parentPath) {
-			parentPath = filepath.Join(configDir, parentPath)
+		parentPath, resolveErr := resolveExtendsPath(configDir, cfg.Extends)
+		if resolveErr != nil {
+			return application.Config{}, fmt.Errorf("resolving extends %q: %w", cfg.Extends, resolveErr)
 		}
 
 		parentCfg, err = l.loadWithCycleCheck(parentPath, visited)
@@ -216,6 +218,66 @@ func (l Loader) loadWithCycleCheck(path string, visited map[string]struct{}) (ap
 	}
 
 	return childCfg, nil
+}
+
+// resolveExtendsPath resolves an `extends:` value relative to the directory of
+// the config that declared it, enforcing containment.
+//
+// An `extends` value is attacker-influenced: an untrusted repository can ship a
+// .coverctl.yaml, so the value must not become an arbitrary-file read
+// primitive. We therefore:
+//   - reject null bytes,
+//   - reject `~`-prefixed paths (no home-directory pivot; no shell expansion
+//     happens so a literal `~` is almost never intended),
+//   - reject absolute paths (callers must use config-relative paths),
+//   - require the resolved parent config to live in an ancestor of, or the same
+//     directory as, the current config. This is the legitimate monorepo pattern
+//     (a child extends a base config located further up the tree) while blocking
+//     sideways escapes such as `../../../../home/user/.ssh/config`.
+//
+// This deliberately does NOT constrain FindConfigFrom's upward walk, which is an
+// intentional monorepo discovery mechanism.
+func resolveExtendsPath(configDir, extends string) (string, error) {
+	if strings.Contains(extends, "\x00") {
+		return "", pathutil.ErrNullBytes
+	}
+	if strings.HasPrefix(extends, "~") {
+		return "", fmt.Errorf("%w: extends must not start with '~'", pathutil.ErrPathEscapesBase)
+	}
+	if filepath.IsAbs(extends) {
+		return "", fmt.Errorf("%w: extends must be a relative path", pathutil.ErrPathEscapesBase)
+	}
+
+	resolved := filepath.Clean(filepath.Join(configDir, extends))
+	// Resolve symlinks (including on the final component) so a symlinked config
+	// cannot point the parent directory outside the allowed scope.
+	if real, err := filepath.EvalSymlinks(resolved); err == nil {
+		resolved = real
+	}
+
+	base := configDir
+	if real, err := filepath.EvalSymlinks(base); err == nil {
+		base = real
+	}
+
+	if !isAncestorOrEqual(filepath.Dir(resolved), base) {
+		return "", fmt.Errorf("%w: extends %q resolves outside the allowed ancestor scope", pathutil.ErrPathEscapesBase, extends)
+	}
+	return resolved, nil
+}
+
+// isAncestorOrEqual reports whether ancestor is the same directory as, or a
+// parent directory of, descendant, using a separator-aware comparison that
+// won't match `/foo/barbaz` against ancestor `/foo/bar`.
+func isAncestorOrEqual(ancestor, descendant string) bool {
+	if ancestor == descendant {
+		return true
+	}
+	prefix := ancestor
+	if !strings.HasSuffix(prefix, string(filepath.Separator)) {
+		prefix += string(filepath.Separator)
+	}
+	return strings.HasPrefix(descendant, prefix)
 }
 
 // buildAppConfig converts a fileConfig to an application.Config

--- a/internal/infrastructure/config/loader_test.go
+++ b/internal/infrastructure/config/loader_test.go
@@ -522,6 +522,61 @@ policy:
 	}
 }
 
+func TestLoadRejectsAbsoluteExtends(t *testing.T) {
+	tmp := t.TempDir()
+	// A secret file the untrusted config tries to read via an absolute extends.
+	secret := filepath.Join(tmp, "secret.yaml")
+	if err := os.WriteFile(secret, []byte("version: 1\npolicy:\n  default:\n    min: 99\n"), 0o644); err != nil {
+		t.Fatalf("write secret: %v", err)
+	}
+	child := "version: 1\nextends: " + secret + "\npolicy:\n  default:\n    min: 50\n"
+	childPath := filepath.Join(tmp, ".coverctl.yaml")
+	if err := os.WriteFile(childPath, []byte(child), 0o644); err != nil {
+		t.Fatalf("write child: %v", err)
+	}
+	if _, err := (Loader{}).Load(childPath); err == nil {
+		t.Fatal("expected absolute extends to be rejected")
+	}
+}
+
+func TestLoadRejectsTildeExtends(t *testing.T) {
+	tmp := t.TempDir()
+	child := "version: 1\nextends: ~/secret.yaml\npolicy:\n  default:\n    min: 50\n"
+	childPath := filepath.Join(tmp, ".coverctl.yaml")
+	if err := os.WriteFile(childPath, []byte(child), 0o644); err != nil {
+		t.Fatalf("write child: %v", err)
+	}
+	if _, err := (Loader{}).Load(childPath); err == nil {
+		t.Fatal("expected ~-prefixed extends to be rejected")
+	}
+}
+
+func TestLoadRejectsExtendsEscapingAncestorScope(t *testing.T) {
+	tmp := t.TempDir()
+	// A sibling subtree outside the child's ancestor chain.
+	outsideDir := filepath.Join(tmp, "outside")
+	if err := os.MkdirAll(outsideDir, 0o755); err != nil {
+		t.Fatalf("mkdir outside: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(outsideDir, "secret.yaml"),
+		[]byte("version: 1\npolicy:\n  default:\n    min: 99\n"), 0o644); err != nil {
+		t.Fatalf("write secret: %v", err)
+	}
+	insideDir := filepath.Join(tmp, "inside")
+	if err := os.MkdirAll(insideDir, 0o755); err != nil {
+		t.Fatalf("mkdir inside: %v", err)
+	}
+	// `../outside/secret.yaml` walks up then sideways into a non-ancestor tree.
+	child := "version: 1\nextends: ../outside/secret.yaml\npolicy:\n  default:\n    min: 50\n"
+	childPath := filepath.Join(insideDir, ".coverctl.yaml")
+	if err := os.WriteFile(childPath, []byte(child), 0o644); err != nil {
+		t.Fatalf("write child: %v", err)
+	}
+	if _, err := (Loader{}).Load(childPath); err == nil {
+		t.Fatal("expected extends escaping the ancestor scope to be rejected")
+	}
+}
+
 func TestLoadWithCircularExtends(t *testing.T) {
 	tmp := t.TempDir()
 


### PR DESCRIPTION
## Summary

Two path-containment gaps found in a deep review. Both validated semi-trusted, externally-influenced paths with the non-containment `pathutil.ValidatePath`, allowing reads outside the intended scope. Both now use containment-aware validation.

## Fix 1 (MED) — annotation scanner read files outside the module root

`internal/infrastructure/annotations/scanner.go` validated coverage-map-derived file paths with `pathutil.ValidatePath` (no scope enforcement), so a `..` or symlink entry in a coverage report could open a file outside the module root.

- Now validates each path with `pathutil.ValidateScopedPath(file, moduleRoot)` and skips (`continue`) on an escape error.
- When `moduleRoot == ""`, containment cannot be proven, so the read is skipped rather than joining an attacker-influenced `../` path freely.

## Fix 2 (MED) — config `extends` was an arbitrary-file read primitive

`internal/infrastructure/config/loader.go` resolved an `extends:` value with only `ValidatePath`, so an untrusted `.coverctl.yaml` with `extends: ../../../../home/user/.ssh/config` (or an absolute / `~` path) could read or probe files anywhere.

- New `resolveExtendsPath` rejects null bytes, `~`-prefixed, and absolute `extends` values, and requires the resolved parent config to live in an **ancestor of (or the same directory as)** the current config — the legitimate monorepo pattern — blocking sideways escapes into non-ancestor subtrees. Final-component symlinks are resolved before the check.
- The intentional upward `FindConfigFrom` monorepo walk is untouched; genuine relative `../..`-style extends to an ancestor config still work (existing `TestLoadWithRelativeExtends` passes).

## Tests

- annotations: `TestScannerSkipsPathEscapingModuleRoot` (a `../secret.go` escape is skipped, not read), `TestScannerSkipsWhenModuleRootEmpty`.
- config: `TestLoadRejectsAbsoluteExtends`, `TestLoadRejectsTildeExtends`, `TestLoadRejectsExtendsEscapingAncestorScope`.

## Verification

- `gofmt -l internal/` — clean
- `go build ./...` — OK
- `go test ./...` — all pass
- `golangci-lint run ./...` — 0 issues

CHANGELOG intentionally not touched (batched separately).

https://claude.ai/code/session_01QKTcmXFTKoTQr7mB3HCuHZ
