### PR TITLE
fix(resolver): correct ** matching and fail closed on zero-match domains

### DIFF
--- a/internal/infrastructure/resolver/glob.go
+++ b/internal/infrastructure/resolver/glob.go
@@ -3,6 +3,7 @@ package resolver
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -29,21 +30,45 @@ func NewGlobResolver(projectDir string) *GlobResolver {
 func (r *GlobResolver) Resolve(ctx context.Context, domains []domain.Domain) (map[string][]string, error) {
 	result := make(map[string][]string, len(domains))
 
+	var problems []string
 	for _, d := range domains {
 		dirs := make([]string, 0)
 		for _, pattern := range d.Match {
-			// Normalize pattern
-			pattern = normalizePattern(pattern, r.projectDir)
+			// Normalize pattern to an absolute glob rooted at the project dir.
+			norm := normalizePattern(pattern, r.projectDir)
 
-			// Find matching directories
-			matches, err := r.globDirs(pattern)
+			// Containment check: reject patterns whose static base escapes the
+			// project directory (e.g. "../../../*"), which would otherwise
+			// enumerate directories outside the repository.
+			if !patternWithinBase(norm, r.projectDir) {
+				problems = append(problems, fmt.Sprintf(
+					"domain %q pattern %q escapes project directory", d.Name, pattern))
+				continue
+			}
+
+			// Find matching directories. Surface real glob errors instead of
+			// swallowing them, so a broken pattern cannot silently fail open.
+			matches, err := r.globDirs(norm)
 			if err != nil {
-				// Ignore glob errors, just skip this pattern
+				problems = append(problems, fmt.Sprintf(
+					"domain %q pattern %q: %v", d.Name, pattern, err))
 				continue
 			}
 			dirs = append(dirs, matches...)
 		}
 		result[d.Name] = unique(dirs)
+
+		// Fail closed: a domain that declares match patterns but resolves to
+		// zero directories would have no files attributed to it, silently
+		// skipping its coverage threshold. Surface this as an error.
+		if len(d.Match) > 0 && len(result[d.Name]) == 0 {
+			problems = append(problems, fmt.Sprintf(
+				"domain %q: pattern(s) %v matched no directories", d.Name, d.Match))
+		}
+	}
+
+	if len(problems) > 0 {
+		return result, fmt.Errorf("glob resolver: %s", strings.Join(problems, "; "))
 	}
 
 	return result, nil
@@ -104,48 +129,132 @@ func (r *GlobResolver) globDirs(pattern string) ([]string, error) {
 }
 
 // recursiveGlob handles ** patterns for recursive directory matching.
+//
+// It walks the tree rooted at the pattern's static (wildcard-free) prefix and
+// matches each directory against the full pattern using doublestar-style
+// segment matching, where "**" matches zero or more path segments. This makes
+// "<base>/**" resolve <base> and every directory beneath it, and "**/handlers"
+// resolve directories whose final segment is "handlers" at any depth, without
+// collapsing multi-segment suffixes (e.g. "**/api/handlers").
 func (r *GlobResolver) recursiveGlob(pattern string) ([]string, error) {
-	// Split pattern at **
-	parts := strings.SplitN(pattern, "**", 2)
-	if len(parts) != 2 {
-		return filepath.Glob(pattern)
+	sep := string(filepath.Separator)
+
+	// Root the walk at the static prefix so we do not scan the whole disk.
+	root := staticWalkRoot(pattern)
+	if root == "" {
+		root = r.projectDir
 	}
 
-	baseDir := strings.TrimSuffix(parts[0], string(filepath.Separator))
-	if baseDir == "" {
-		baseDir = r.projectDir
+	// A non-existent root simply yields zero matches; the domain-level
+	// zero-match check in Resolve is responsible for failing closed.
+	if _, err := os.Stat(root); err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
 	}
 
-	suffix := strings.TrimPrefix(parts[1], string(filepath.Separator))
+	patSegs := strings.Split(pattern, sep)
 
 	var dirs []string
-	err := filepath.Walk(baseDir, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return nil // Ignore errors
+	err := filepath.Walk(root, func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return nil // Ignore per-entry traversal errors, keep walking.
 		}
 		if !info.IsDir() {
 			return nil
 		}
 
 		// Skip hidden directories
-		if strings.HasPrefix(info.Name(), ".") && path != baseDir {
+		if strings.HasPrefix(info.Name(), ".") && path != root {
 			return filepath.SkipDir
 		}
 
-		// If there's a suffix pattern, check if it matches
-		if suffix != "" {
-			// For patterns like **/tests, check if the directory name matches
-			suffixBase := filepath.Base(suffix)
-			if suffixBase != "*" && info.Name() != suffixBase {
-				return nil
-			}
+		ok, matchErr := matchSegments(patSegs, strings.Split(path, sep))
+		if matchErr != nil {
+			return matchErr // Surface malformed patterns (e.g. bad char class).
 		}
-
-		dirs = append(dirs, path)
+		if ok {
+			dirs = append(dirs, path)
+		}
 		return nil
 	})
 
 	return dirs, err
+}
+
+// staticWalkRoot returns the leading wildcard-free portion of an absolute
+// pattern, used to root a recursive walk. For "/a/b/**/c" it returns "/a/b";
+// for "/a/**" it returns "/a"; for "/*" it returns "/".
+func staticWalkRoot(pattern string) string {
+	sep := string(filepath.Separator)
+	segs := strings.Split(pattern, sep)
+
+	base := make([]string, 0, len(segs))
+	for _, s := range segs {
+		if s == "**" || strings.ContainsAny(s, "*?[") {
+			break
+		}
+		base = append(base, s)
+	}
+
+	root := strings.Join(base, sep)
+	if root == "" && strings.HasPrefix(pattern, sep) {
+		root = sep
+	}
+	return root
+}
+
+// matchSegments reports whether the path segments match the pattern segments
+// using doublestar semantics: a "**" segment matches zero or more path
+// segments, and every other segment is matched with filepath.Match (so "*",
+// "?" and character classes work within a single segment).
+func matchSegments(pat, name []string) (bool, error) {
+	if len(pat) == 0 {
+		return len(name) == 0, nil
+	}
+
+	if pat[0] == "**" {
+		// Try consuming zero segments with "**".
+		if ok, err := matchSegments(pat[1:], name); ok || err != nil {
+			return ok, err
+		}
+		// Otherwise consume one segment and keep "**" active.
+		if len(name) == 0 {
+			return false, nil
+		}
+		return matchSegments(pat, name[1:])
+	}
+
+	if len(name) == 0 {
+		return false, nil
+	}
+
+	ok, err := filepath.Match(pat[0], name[0])
+	if err != nil {
+		return false, err
+	}
+	if !ok {
+		return false, nil
+	}
+	return matchSegments(pat[1:], name[1:])
+}
+
+// patternWithinBase reports whether a normalized pattern's static base stays
+// inside baseDir. It guards against config patterns like "../../../*" that
+// would resolve outside the project directory.
+func patternWithinBase(pattern, baseDir string) bool {
+	root := staticWalkRoot(pattern)
+	if root == "" {
+		// Purely relative/wildcard-first patterns walk from the project dir.
+		return true
+	}
+
+	rel, err := filepath.Rel(baseDir, root)
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }
 
 // unique removes duplicate strings from a slice.

--- a/internal/infrastructure/resolver/glob_test.go
+++ b/internal/infrastructure/resolver/glob_test.go
@@ -90,6 +90,170 @@ func TestGlobResolverResolve(t *testing.T) {
 	}
 }
 
+// TestGlobResolverDoublestarMatching verifies doublestar-style "**" segment
+// matching for the previously broken "<base>/**" and "**/<name>" cases.
+func TestGlobResolverDoublestarMatching(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	dirs := []string{
+		"src/api/handlers",
+		"src/core/handlers",
+		"src/core/internal",
+		"src/utils",
+		"web/handlers",
+		"lib/handlers/nested",
+	}
+	for _, dir := range dirs {
+		if err := os.MkdirAll(filepath.Join(tmpDir, dir), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	resolver := NewGlobResolver(tmpDir)
+
+	tests := []struct {
+		name    string
+		pattern string
+		// wantContains lists directories (relative to tmpDir) that MUST resolve.
+		wantContains []string
+		// wantExcludes lists directories that must NOT resolve.
+		wantExcludes []string
+	}{
+		{
+			name:    "base doublestar resolves dir and all descendants",
+			pattern: "src/**",
+			wantContains: []string{
+				"src", "src/api", "src/api/handlers",
+				"src/core", "src/core/handlers", "src/core/internal", "src/utils",
+			},
+			wantExcludes: []string{"web", "web/handlers", "lib/handlers"},
+		},
+		{
+			name:    "leading doublestar matches final segment at any depth",
+			pattern: "**/handlers",
+			wantContains: []string{
+				"src/api/handlers", "src/core/handlers",
+				"web/handlers", "lib/handlers",
+			},
+			// Must not match dirs whose final segment is not "handlers",
+			// even when a "handlers" dir exists elsewhere in the path.
+			wantExcludes: []string{"src", "src/core/internal", "lib/handlers/nested"},
+		},
+		{
+			name:         "multi-segment suffix does not collapse to basename",
+			pattern:      "**/core/handlers",
+			wantContains: []string{"src/core/handlers"},
+			// "**/core/handlers" must NOT match "src/api/handlers" (parent != core).
+			wantExcludes: []string{"src/api/handlers", "web/handlers", "lib/handlers"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := resolver.Resolve(context.Background(), []domain.Domain{
+				{Name: "d", Match: []string{tt.pattern}},
+			})
+			if err != nil {
+				t.Fatalf("Resolve() error = %v", err)
+			}
+
+			got := make(map[string]bool)
+			for _, d := range result["d"] {
+				rel, relErr := filepath.Rel(tmpDir, d)
+				if relErr != nil {
+					t.Fatalf("Rel() error = %v", relErr)
+				}
+				got[rel] = true
+			}
+
+			for _, want := range tt.wantContains {
+				if !got[want] {
+					t.Errorf("pattern %q: expected to resolve %q, got %v", tt.pattern, want, keys(got))
+				}
+			}
+			for _, exclude := range tt.wantExcludes {
+				if got[exclude] {
+					t.Errorf("pattern %q: expected NOT to resolve %q, got %v", tt.pattern, exclude, keys(got))
+				}
+			}
+		})
+	}
+}
+
+// TestGlobResolverZeroMatchFailsClosed verifies that a domain whose patterns
+// resolve to zero directories surfaces an error rather than silently passing.
+func TestGlobResolverZeroMatchFailsClosed(t *testing.T) {
+	tmpDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tmpDir, "src", "api"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	resolver := NewGlobResolver(tmpDir)
+
+	tests := []struct {
+		name    string
+		pattern string
+	}{
+		{"non-existent plain directory", "does/not/exist"},
+		{"non-existent recursive base", "missing/**"},
+		{"recursive suffix matches nothing", "**/nonexistent"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := resolver.Resolve(context.Background(), []domain.Domain{
+				{Name: "ghost", Match: []string{tt.pattern}},
+			})
+			if err == nil {
+				t.Fatalf("pattern %q: expected zero-match error, got nil (silent fail-open)", tt.pattern)
+			}
+		})
+	}
+
+	// A valid domain alongside an invalid one still surfaces the error.
+	_, err := resolver.Resolve(context.Background(), []domain.Domain{
+		{Name: "api", Match: []string{"src/api"}},
+		{Name: "ghost", Match: []string{"does/not/exist"}},
+	})
+	if err == nil {
+		t.Fatal("expected error when one domain matches no directories")
+	}
+}
+
+// TestGlobResolverContainsEscape verifies that a pattern escaping the project
+// directory is contained (not enumerated) and surfaced as an error.
+func TestGlobResolverContainsEscape(t *testing.T) {
+	tmpDir := t.TempDir()
+	sub := filepath.Join(tmpDir, "project")
+	if err := os.MkdirAll(filepath.Join(sub, "src"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Sibling directory outside the project that an escaping pattern would hit.
+	if err := os.MkdirAll(filepath.Join(tmpDir, "outside"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	resolver := NewGlobResolver(sub)
+
+	result, err := resolver.Resolve(context.Background(), []domain.Domain{
+		{Name: "escape", Match: []string{"../../../*"}},
+	})
+	if err == nil {
+		t.Fatal("expected error for pattern escaping project directory")
+	}
+	if len(result["escape"]) != 0 {
+		t.Errorf("escaping pattern must resolve no directories, got %v", result["escape"])
+	}
+}
+
+func keys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
 func TestGlobResolverModuleRoot(t *testing.T) {
 	tmpDir := t.TempDir()
 	resolver := NewGlobResolver(tmpDir)


### PR DESCRIPTION
## Summary

Fixes a **fail-open** defect in the glob domain resolver (`internal/infrastructure/resolver/glob.go`): a domain whose `match:` pattern resolved to zero directories had no files attributed to it, so its coverage threshold was silently unenforced. Two related correctness bugs in `**` handling and one path-escape hole are fixed alongside.

## Problems

1. **Broken `**` matching.** `recursiveGlob` reduced the post-`**` suffix to `filepath.Base(suffix)` and required a directory's *name* to equal it. Consequences:
   - `src/**/*.py` → suffix base `*.py`, which no directory name equals → **zero matches**.
   - `**/api/handlers` collapsed to base `handlers`, matching **any** `handlers` dir regardless of parent → **over-match**.
2. **Errors swallowed / silent zero-match.** `Resolve` dropped glob errors with `continue`, and a domain ending with an empty directory list passed silently — the fail-open.
3. **Path escape.** `normalizePattern` does `filepath.Join(baseDir, pattern)`, so a config `match: "../../../*"` escaped the project directory and enumerated dirs outside the repo.

## Fixes

- **Proper doublestar segment matching.** `recursiveGlob` now walks the tree rooted at the pattern's static prefix and matches each directory against the full pattern segment-by-segment, where `**` matches zero or more segments (`matchSegments` + `staticWalkRoot`). `src/**` resolves `src` and every descendant; `**/handlers` matches only dirs whose final segment is `handlers`; `**/core/handlers` no longer collapses to any `handlers` dir. Per-segment wildcards (`*`, `?`, char classes) still work via `filepath.Match`.
- **Fail closed.** `Resolve` aggregates problems and returns an error when any pattern is malformed or when a domain with declared patterns resolves to zero directories. All callers already propagate the `Resolve` error, so the check now errors instead of silently passing.
- **Containment check.** `patternWithinBase` rejects patterns whose static base escapes the project directory.

## Tests

Added (existing resolver tests preserved and passing):
- `TestGlobResolverDoublestarMatching` — `src/**` resolves the right dirs; `**/handlers` does not over/under-match; multi-segment suffix `**/core/handlers` does not collapse to basename.
- `TestGlobResolverZeroMatchFailsClosed` — non-existent plain/recursive/suffix patterns surface an error (not a silent pass), including a mixed valid+invalid domain set.
- `TestGlobResolverContainsEscape` — a `../` escaping pattern resolves nothing and errors.

Verified: `gofmt -l internal/` empty, `go build ./...`, `go test ./...`, `golangci-lint run ./...` → 0 issues.

Scope: only `internal/infrastructure/resolver/` touched; CHANGELOG.md untouched.

https://claude.ai/code/session_01QKTcmXFTKoTQr7mB3HCuHZ
