### PR TITLE
fix(vcs): harden GitHub/GitLab/Bitbucket API clients

### DIFF
--- a/internal/infrastructure/bitbucket/client.go
+++ b/internal/infrastructure/bitbucket/client.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -25,7 +26,29 @@ const (
 	DefaultAPIURL = "https://api.bitbucket.org/2.0"
 	// CommentMarker identifies coverctl comments for updates
 	CommentMarker = "<!-- coverctl-coverage-report -->"
+	// maxResponseBytes caps how much of an API response body we buffer, to
+	// avoid unbounded memory use if a server returns a huge (or malicious) body.
+	maxResponseBytes = 5 << 20 // 5 MiB
+	// maxCommentPages bounds how many pagination pages FindCoverageComment
+	// will follow, so a server that returns an endless "next" chain cannot
+	// trap the client in an unbounded loop.
+	maxCommentPages = 100
 )
+
+// checkRedirect refuses to follow a redirect that crosses to a different host.
+//
+// Bitbucket uses HTTP Basic auth, which Go's http.Client already strips on a
+// cross-host redirect, but blocking cross-host redirects outright is a
+// consistent, defense-in-depth policy shared across all VCS clients.
+func checkRedirect(req *http.Request, via []*http.Request) error {
+	if len(via) == 0 {
+		return nil
+	}
+	if req.URL.Host != via[0].URL.Host {
+		return fmt.Errorf("refusing cross-host redirect to %q", req.URL.Host)
+	}
+	return nil
+}
 
 // Client implements the PRClient interface for Bitbucket API.
 type Client struct {
@@ -54,7 +77,7 @@ func NewClient(username, appPassword string) *Client {
 		}
 	}
 	return &Client{
-		httpClient:  &http.Client{Timeout: DefaultHTTPTimeout},
+		httpClient:  &http.Client{Timeout: DefaultHTTPTimeout, CheckRedirect: checkRedirect},
 		apiURL:      DefaultAPIURL,
 		username:    username,
 		appPassword: appPassword,
@@ -74,6 +97,11 @@ func NewClientWithHTTP(username, appPassword string, httpClient *http.Client, ap
 	}
 	if apiURL == "" {
 		apiURL = DefaultAPIURL
+	}
+	// Apply the same cross-host redirect protection as NewClient. Guard against
+	// http.DefaultClient so we never mutate the process-wide shared client.
+	if httpClient != nil && httpClient != http.DefaultClient {
+		httpClient.CheckRedirect = checkRedirect
 	}
 	return &Client{
 		httpClient:  httpClient,
@@ -104,46 +132,70 @@ type commentList struct {
 
 // FindCoverageComment finds an existing coverage comment on a PR.
 // Returns 0 if no comment found.
+//
+// Bitbucket paginates comments, so this follows the "next" link across pages
+// until the marker is found or the pages are exhausted. Without this, an
+// existing coverctl comment on page 2+ would be missed and CreateComment would
+// post a duplicate instead of UpdateComment updating the existing one.
 func (c *Client) FindCoverageComment(ctx context.Context, workspace, repoSlug string, prNumber int) (int64, error) {
-	url := fmt.Sprintf("%s/repositories/%s/%s/pullrequests/%d/comments", c.apiURL, workspace, repoSlug, prNumber)
+	pageURL := fmt.Sprintf("%s/repositories/%s/%s/pullrequests/%d/comments",
+		c.apiURL, url.PathEscape(workspace), url.PathEscape(repoSlug), prNumber)
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	for page := 0; pageURL != "" && page < maxCommentPages; page++ {
+		id, next, err := c.findMarkerOnPage(ctx, pageURL)
+		if err != nil {
+			return 0, err
+		}
+		if id != 0 {
+			return id, nil
+		}
+		pageURL = next
+	}
+
+	return 0, nil
+}
+
+// findMarkerOnPage fetches a single page of comments and returns the ID of the
+// comment carrying our marker (or 0), plus the URL of the next page (or "").
+func (c *Client) findMarkerOnPage(ctx context.Context, pageURL string) (int64, string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, pageURL, nil)
 	if err != nil {
-		return 0, fmt.Errorf("create request: %w", err)
+		return 0, "", fmt.Errorf("create request: %w", err)
 	}
 
 	c.setHeaders(req)
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return 0, fmt.Errorf("http request: %w", err)
+		return 0, "", fmt.Errorf("http request: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return 0, fmt.Errorf("bitbucket API error: %s - %s", resp.Status, string(body))
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+		return 0, "", fmt.Errorf("bitbucket API error: %s - %s", resp.Status, string(body))
 	}
 
 	var comments commentList
-	if err := json.NewDecoder(resp.Body).Decode(&comments); err != nil {
-		return 0, fmt.Errorf("decode response: %w", err)
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxResponseBytes)).Decode(&comments); err != nil {
+		return 0, "", fmt.Errorf("decode response: %w", err)
 	}
 
 	// Find comment with our marker
 	for _, comment := range comments.Values {
 		if strings.Contains(comment.Content.Raw, CommentMarker) {
-			return comment.ID, nil
+			return comment.ID, "", nil
 		}
 	}
 
-	return 0, nil
+	return 0, comments.Next, nil
 }
 
 // CreateComment creates a new comment on a PR.
 // Returns the comment ID and URL.
 func (c *Client) CreateComment(ctx context.Context, workspace, repoSlug string, prNumber int, body string) (int64, string, error) {
-	url := fmt.Sprintf("%s/repositories/%s/%s/pullrequests/%d/comments", c.apiURL, workspace, repoSlug, prNumber)
+	apiURL := fmt.Sprintf("%s/repositories/%s/%s/pullrequests/%d/comments",
+		c.apiURL, url.PathEscape(workspace), url.PathEscape(repoSlug), prNumber)
 
 	payload := map[string]any{
 		"content": map[string]string{
@@ -155,7 +207,7 @@ func (c *Client) CreateComment(ctx context.Context, workspace, repoSlug string, 
 		return 0, "", fmt.Errorf("marshal body: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(jsonBody))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, apiURL, bytes.NewReader(jsonBody))
 	if err != nil {
 		return 0, "", fmt.Errorf("create request: %w", err)
 	}
@@ -170,12 +222,12 @@ func (c *Client) CreateComment(ctx context.Context, workspace, repoSlug string, 
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusCreated {
-		respBody, _ := io.ReadAll(resp.Body)
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
 		return 0, "", fmt.Errorf("bitbucket API error: %s - %s", resp.Status, string(respBody))
 	}
 
 	var comment comment
-	if err := json.NewDecoder(resp.Body).Decode(&comment); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxResponseBytes)).Decode(&comment); err != nil {
 		return 0, "", fmt.Errorf("decode response: %w", err)
 	}
 
@@ -184,7 +236,8 @@ func (c *Client) CreateComment(ctx context.Context, workspace, repoSlug string, 
 
 // UpdateComment updates an existing comment.
 func (c *Client) UpdateComment(ctx context.Context, workspace, repoSlug string, commentID int64, body string) error {
-	url := fmt.Sprintf("%s/repositories/%s/%s/pullrequests/comments/%d", c.apiURL, workspace, repoSlug, commentID)
+	apiURL := fmt.Sprintf("%s/repositories/%s/%s/pullrequests/comments/%d",
+		c.apiURL, url.PathEscape(workspace), url.PathEscape(repoSlug), commentID)
 
 	payload := map[string]any{
 		"content": map[string]string{
@@ -196,7 +249,7 @@ func (c *Client) UpdateComment(ctx context.Context, workspace, repoSlug string, 
 		return fmt.Errorf("marshal body: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPut, url, bytes.NewReader(jsonBody))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, apiURL, bytes.NewReader(jsonBody))
 	if err != nil {
 		return fmt.Errorf("create request: %w", err)
 	}
@@ -211,7 +264,7 @@ func (c *Client) UpdateComment(ctx context.Context, workspace, repoSlug string, 
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		respBody, _ := io.ReadAll(resp.Body)
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
 		return fmt.Errorf("bitbucket API error: %s - %s", resp.Status, string(respBody))
 	}
 

--- a/internal/infrastructure/bitbucket/client_test.go
+++ b/internal/infrastructure/bitbucket/client_test.go
@@ -1,6 +1,7 @@
 package bitbucket
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"net/http"
@@ -11,6 +12,15 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.klarlabs.de/coverctl/internal/application"
 )
+
+// rawContent builds the anonymous content struct used by comment values.
+func rawContent(raw string) struct {
+	Raw string `json:"raw"`
+} {
+	return struct {
+		Raw string `json:"raw"`
+	}{Raw: raw}
+}
 
 // newTestServer creates an httptest.Server and returns a Client wired to it.
 // The server is registered for cleanup via t.Cleanup, so callers only need
@@ -67,6 +77,93 @@ func TestBasicAuthHeader(t *testing.T) {
 	require.True(t, authOK, "basic auth header must be present")
 	assert.Equal(t, "testuser", capturedUsername)
 	assert.Equal(t, "testpass", capturedPassword)
+}
+
+func TestFindCoverageCommentRejectsCrossHostRedirect(t *testing.T) {
+	var attackerHit bool
+	var attackerUser, attackerPass string
+	attacker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attackerHit = true
+		attackerUser, attackerPass, _ = r.BasicAuth()
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(commentList{})
+	}))
+	defer attacker.Close()
+
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, attacker.URL+"/steal", http.StatusFound)
+	}))
+	defer primary.Close()
+
+	client := NewClientWithHTTP("secretuser", "secretpass", primary.Client(), primary.URL)
+	_, err := client.FindCoverageComment(context.Background(), "ws", "repo", 1)
+
+	require.Error(t, err)
+	assert.False(t, attackerHit, "client must not follow a redirect to a different host")
+	assert.Empty(t, attackerUser, "credentials must not be forwarded to the attacker host")
+	assert.Empty(t, attackerPass, "credentials must not be forwarded to the attacker host")
+}
+
+func TestFindCoverageCommentEscapesPathSegments(t *testing.T) {
+	var gotEscapedPath, gotRawQuery string
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotEscapedPath = r.URL.EscapedPath()
+		gotRawQuery = r.URL.RawQuery
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(commentList{})
+	})
+
+	client := newTestServer(t, handler)
+	_, err := client.FindCoverageComment(context.Background(), "ws", "../evil?injected=1", 1)
+	require.NoError(t, err)
+	assert.Contains(t, gotEscapedPath, "..%2Fevil%3Finjected=1")
+	assert.Empty(t, gotRawQuery, "query characters must not leak into the request query")
+}
+
+func TestFindCoverageCommentBoundsResponseBody(t *testing.T) {
+	oversized := bytes.Repeat([]byte("a"), maxResponseBytes+1024)
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"values":[{"id":1,"content":{"raw":"`))
+		_, _ = w.Write(oversized)
+		// Intentionally never closed: the body exceeds maxResponseBytes.
+	})
+
+	client := newTestServer(t, handler)
+	_, err := client.FindCoverageComment(context.Background(), "ws", "repo", 1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "decode response")
+}
+
+func TestFindCoverageCommentFollowsPagination(t *testing.T) {
+	var requestCount int
+	var baseURL string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.WriteHeader(http.StatusOK)
+		if r.URL.Query().Get("page") == "2" {
+			// Page 2 carries the existing coverctl comment.
+			_ = json.NewEncoder(w).Encode(commentList{
+				Values: []comment{
+					{ID: 77, Content: rawContent("Coverage report\n" + CommentMarker)},
+				},
+			})
+			return
+		}
+		// Page 1: no marker, but points to page 2 on the same host.
+		_ = json.NewEncoder(w).Encode(commentList{
+			Values: []comment{{ID: 10, Content: rawContent("unrelated comment")}},
+			Next:   baseURL + "/repositories/ws/repo/pullrequests/5/comments?page=2",
+		})
+	}))
+	defer srv.Close()
+	baseURL = srv.URL
+
+	client := NewClientWithHTTP("testuser", "testpass", srv.Client(), srv.URL)
+	id, err := client.FindCoverageComment(context.Background(), "ws", "repo", 5)
+	require.NoError(t, err)
+	assert.Equal(t, int64(77), id, "must find the comment on page 2 via the next link")
+	assert.Equal(t, 2, requestCount, "must follow pagination to the second page")
 }
 
 func TestFindCoverageComment(t *testing.T) {

--- a/internal/infrastructure/github/client.go
+++ b/internal/infrastructure/github/client.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -25,7 +26,25 @@ const (
 	DefaultAPIURL = "https://api.github.com"
 	// CommentMarker identifies coverctl comments for updates
 	CommentMarker = "<!-- coverctl-coverage-report -->"
+	// maxResponseBytes caps how much of an API response body we buffer, to
+	// avoid unbounded memory use if a server returns a huge (or malicious) body.
+	maxResponseBytes = 5 << 20 // 5 MiB
 )
+
+// checkRedirect refuses to follow a redirect that crosses to a different host.
+//
+// GitHub uses an Authorization header, which Go's http.Client already strips
+// on a cross-host redirect, but blocking cross-host redirects outright is a
+// consistent, defense-in-depth policy shared across all VCS clients.
+func checkRedirect(req *http.Request, via []*http.Request) error {
+	if len(via) == 0 {
+		return nil
+	}
+	if req.URL.Host != via[0].URL.Host {
+		return fmt.Errorf("refusing cross-host redirect to %q", req.URL.Host)
+	}
+	return nil
+}
 
 // Client implements the PRClient interface for GitHub API.
 type Client struct {
@@ -46,7 +65,7 @@ func NewClient(token string) *Client {
 		token = os.Getenv("GITHUB_TOKEN")
 	}
 	return &Client{
-		httpClient: &http.Client{Timeout: DefaultHTTPTimeout},
+		httpClient: &http.Client{Timeout: DefaultHTTPTimeout, CheckRedirect: checkRedirect},
 		apiURL:     DefaultAPIURL,
 		token:      token,
 	}
@@ -70,6 +89,11 @@ func NewClientWithHTTP(token string, httpClient *http.Client, apiURL string) *Cl
 	if apiURL == "" {
 		apiURL = DefaultAPIURL
 	}
+	// Apply the same cross-host redirect protection as NewClient. Guard against
+	// http.DefaultClient so we never mutate the process-wide shared client.
+	if httpClient != nil && httpClient != http.DefaultClient {
+		httpClient.CheckRedirect = checkRedirect
+	}
 	return &Client{
 		httpClient: httpClient,
 		apiURL:     apiURL,
@@ -87,9 +111,9 @@ type issueComment struct {
 // FindCoverageComment finds an existing coverage comment on a PR.
 // Returns 0 if no comment found.
 func (c *Client) FindCoverageComment(ctx context.Context, owner, repo string, prNumber int) (int64, error) {
-	url := fmt.Sprintf("%s/repos/%s/%s/issues/%d/comments", c.apiURL, owner, repo, prNumber)
+	apiURL := fmt.Sprintf("%s/repos/%s/%s/issues/%d/comments", c.apiURL, url.PathEscape(owner), url.PathEscape(repo), prNumber)
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
 	if err != nil {
 		return 0, fmt.Errorf("create request: %w", err)
 	}
@@ -104,12 +128,12 @@ func (c *Client) FindCoverageComment(ctx context.Context, owner, repo string, pr
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
 		return 0, fmt.Errorf("GitHub API error: %s - %s", resp.Status, string(body))
 	}
 
 	var comments []issueComment
-	if err := json.NewDecoder(resp.Body).Decode(&comments); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxResponseBytes)).Decode(&comments); err != nil {
 		return 0, fmt.Errorf("decode response: %w", err)
 	}
 
@@ -126,7 +150,7 @@ func (c *Client) FindCoverageComment(ctx context.Context, owner, repo string, pr
 // CreateComment creates a new comment on a PR.
 // Returns the comment ID and URL.
 func (c *Client) CreateComment(ctx context.Context, owner, repo string, prNumber int, body string) (int64, string, error) {
-	url := fmt.Sprintf("%s/repos/%s/%s/issues/%d/comments", c.apiURL, owner, repo, prNumber)
+	apiURL := fmt.Sprintf("%s/repos/%s/%s/issues/%d/comments", c.apiURL, url.PathEscape(owner), url.PathEscape(repo), prNumber)
 
 	payload := map[string]string{"body": body}
 	jsonBody, err := json.Marshal(payload)
@@ -134,7 +158,7 @@ func (c *Client) CreateComment(ctx context.Context, owner, repo string, prNumber
 		return 0, "", fmt.Errorf("marshal body: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(jsonBody))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, apiURL, bytes.NewReader(jsonBody))
 	if err != nil {
 		return 0, "", fmt.Errorf("create request: %w", err)
 	}
@@ -150,12 +174,12 @@ func (c *Client) CreateComment(ctx context.Context, owner, repo string, prNumber
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusCreated {
-		respBody, _ := io.ReadAll(resp.Body)
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
 		return 0, "", fmt.Errorf("GitHub API error: %s - %s", resp.Status, string(respBody))
 	}
 
 	var comment issueComment
-	if err := json.NewDecoder(resp.Body).Decode(&comment); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxResponseBytes)).Decode(&comment); err != nil {
 		return 0, "", fmt.Errorf("decode response: %w", err)
 	}
 
@@ -164,7 +188,7 @@ func (c *Client) CreateComment(ctx context.Context, owner, repo string, prNumber
 
 // UpdateComment updates an existing comment.
 func (c *Client) UpdateComment(ctx context.Context, owner, repo string, commentID int64, body string) error {
-	url := fmt.Sprintf("%s/repos/%s/%s/issues/comments/%d", c.apiURL, owner, repo, commentID)
+	apiURL := fmt.Sprintf("%s/repos/%s/%s/issues/comments/%d", c.apiURL, url.PathEscape(owner), url.PathEscape(repo), commentID)
 
 	payload := map[string]string{"body": body}
 	jsonBody, err := json.Marshal(payload)
@@ -172,7 +196,7 @@ func (c *Client) UpdateComment(ctx context.Context, owner, repo string, commentI
 		return fmt.Errorf("marshal body: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, url, bytes.NewReader(jsonBody))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, apiURL, bytes.NewReader(jsonBody))
 	if err != nil {
 		return fmt.Errorf("create request: %w", err)
 	}
@@ -188,7 +212,7 @@ func (c *Client) UpdateComment(ctx context.Context, owner, repo string, commentI
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		respBody, _ := io.ReadAll(resp.Body)
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
 		return fmt.Errorf("GitHub API error: %s - %s", resp.Status, string(respBody))
 	}
 

--- a/internal/infrastructure/github/client_test.go
+++ b/internal/infrastructure/github/client_test.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"net/http"
@@ -61,6 +62,65 @@ func TestAuthHeader(t *testing.T) {
 		require.NoError(t, err)
 		assert.Empty(t, capturedAuthHeader)
 	})
+}
+
+func TestFindCoverageCommentRejectsCrossHostRedirect(t *testing.T) {
+	var attackerHit bool
+	var attackerAuth string
+	attacker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attackerHit = true
+		attackerAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode([]issueComment{})
+	}))
+	defer attacker.Close()
+
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, attacker.URL+"/steal", http.StatusFound)
+	}))
+	defer primary.Close()
+
+	client := NewClientWithHTTP("super-secret-token", primary.Client(), primary.URL)
+	_, err := client.FindCoverageComment(context.Background(), "owner", "repo", 1)
+
+	require.Error(t, err)
+	assert.False(t, attackerHit, "client must not follow a redirect to a different host")
+	assert.Empty(t, attackerAuth, "Authorization must not be forwarded to the attacker host")
+}
+
+func TestFindCoverageCommentEscapesPathSegments(t *testing.T) {
+	var gotEscapedPath, gotRawQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotEscapedPath = r.URL.EscapedPath()
+		gotRawQuery = r.URL.RawQuery
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode([]issueComment{})
+	}))
+	defer srv.Close()
+
+	client := NewClientWithHTTP("token", srv.Client(), srv.URL)
+	// A repo value carrying path-traversal and query characters must be
+	// percent-escaped into a single path segment, not break out of the path.
+	_, err := client.FindCoverageComment(context.Background(), "owner", "../evil?injected=1", 1)
+	require.NoError(t, err)
+	assert.Contains(t, gotEscapedPath, "..%2Fevil%3Finjected=1")
+	assert.Empty(t, gotRawQuery, "query characters must not leak into the request query")
+}
+
+func TestFindCoverageCommentBoundsResponseBody(t *testing.T) {
+	oversized := bytes.Repeat([]byte("a"), maxResponseBytes+1024)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[{"id":1,"body":"`))
+		_, _ = w.Write(oversized)
+		// Intentionally never closed: the body exceeds maxResponseBytes.
+	}))
+	defer srv.Close()
+
+	client := NewClientWithHTTP("token", srv.Client(), srv.URL)
+	_, err := client.FindCoverageComment(context.Background(), "owner", "repo", 1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "decode response")
 }
 
 func TestFindCoverageComment(t *testing.T) {

--- a/internal/infrastructure/gitlab/client.go
+++ b/internal/infrastructure/gitlab/client.go
@@ -26,7 +26,26 @@ const (
 	DefaultAPIURL = "https://gitlab.com/api/v4"
 	// CommentMarker identifies coverctl comments for updates
 	CommentMarker = "<!-- coverctl-coverage-report -->"
+	// maxResponseBytes caps how much of an API response body we buffer, to
+	// avoid unbounded memory use if a server returns a huge (or malicious) body.
+	maxResponseBytes = 5 << 20 // 5 MiB
 )
+
+// checkRedirect refuses to follow a redirect that crosses to a different host.
+//
+// Go's http.Client strips Authorization/Cookie on a cross-host redirect but
+// NOT custom headers such as GitLab's PRIVATE-TOKEN, so an open redirect to an
+// attacker-controlled host would otherwise forward the token. Same-host
+// redirects (path-only changes) remain allowed.
+func checkRedirect(req *http.Request, via []*http.Request) error {
+	if len(via) == 0 {
+		return nil
+	}
+	if req.URL.Host != via[0].URL.Host {
+		return fmt.Errorf("refusing cross-host redirect to %q", req.URL.Host)
+	}
+	return nil
+}
 
 // Client implements the PRClient interface for GitLab API.
 type Client struct {
@@ -50,7 +69,7 @@ func NewClient(token string) *Client {
 		}
 	}
 	return &Client{
-		httpClient: &http.Client{Timeout: DefaultHTTPTimeout},
+		httpClient: &http.Client{Timeout: DefaultHTTPTimeout, CheckRedirect: checkRedirect},
 		apiURL:     DefaultAPIURL,
 		token:      token,
 	}
@@ -76,6 +95,11 @@ func NewClientWithHTTP(token string, httpClient *http.Client, apiURL string) *Cl
 	}
 	if apiURL == "" {
 		apiURL = DefaultAPIURL
+	}
+	// Apply the same cross-host redirect protection as NewClient. Guard against
+	// http.DefaultClient so we never mutate the process-wide shared client.
+	if httpClient != nil && httpClient != http.DefaultClient {
+		httpClient.CheckRedirect = checkRedirect
 	}
 	return &Client{
 		httpClient: httpClient,
@@ -116,12 +140,12 @@ func (c *Client) FindCoverageComment(ctx context.Context, owner, repo string, mr
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
 		return 0, fmt.Errorf("GitLab API error: %s - %s", resp.Status, string(body))
 	}
 
 	var notes []note
-	if err := json.NewDecoder(resp.Body).Decode(&notes); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxResponseBytes)).Decode(&notes); err != nil {
 		return 0, fmt.Errorf("decode response: %w", err)
 	}
 
@@ -162,12 +186,12 @@ func (c *Client) CreateComment(ctx context.Context, owner, repo string, mrNumber
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusCreated {
-		respBody, _ := io.ReadAll(resp.Body)
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
 		return 0, "", fmt.Errorf("GitLab API error: %s - %s", resp.Status, string(respBody))
 	}
 
 	var n note
-	if err := json.NewDecoder(resp.Body).Decode(&n); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxResponseBytes)).Decode(&n); err != nil {
 		return 0, "", fmt.Errorf("decode response: %w", err)
 	}
 
@@ -211,7 +235,7 @@ func (c *Client) UpdateComment(ctx context.Context, owner, repo string, noteID i
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		respBody, _ := io.ReadAll(resp.Body)
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
 		return fmt.Errorf("GitLab API error: %s - %s", resp.Status, string(respBody))
 	}
 

--- a/internal/infrastructure/gitlab/client_test.go
+++ b/internal/infrastructure/gitlab/client_test.go
@@ -60,6 +60,49 @@ func TestAuthHeaderOmittedWhenEmpty(t *testing.T) {
 	assert.False(t, headerPresent, "PRIVATE-TOKEN header should not be set when token is empty")
 }
 
+func TestFindCoverageCommentRejectsCrossHostRedirect(t *testing.T) {
+	var attackerHit bool
+	var attackerToken string
+	attacker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attackerHit = true
+		attackerToken = r.Header.Get("PRIVATE-TOKEN")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("[]"))
+	}))
+	defer attacker.Close()
+
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Redirect to a different host, as an open-redirect attacker would.
+		http.Redirect(w, r, attacker.URL+"/steal", http.StatusFound)
+	}))
+	defer primary.Close()
+
+	client := NewClientWithHTTP("super-secret-token", primary.Client(), primary.URL)
+	_, err := client.FindCoverageComment(context.Background(), "owner", "repo", 1)
+
+	require.Error(t, err)
+	assert.False(t, attackerHit, "client must not follow a redirect to a different host")
+	assert.Empty(t, attackerToken, "PRIVATE-TOKEN must not be forwarded to the attacker host")
+}
+
+func TestFindCoverageCommentBoundsResponseBody(t *testing.T) {
+	// A single JSON value larger than the cap is truncated by the LimitReader,
+	// producing a decode error rather than buffering an unbounded body.
+	oversized := bytes.Repeat([]byte("a"), maxResponseBytes+1024)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[{"id":1,"body":"`))
+		_, _ = w.Write(oversized)
+		// Intentionally never closed: the body exceeds maxResponseBytes.
+	}))
+	defer srv.Close()
+
+	client := NewClientWithHTTP("token", srv.Client(), srv.URL)
+	_, err := client.FindCoverageComment(context.Background(), "owner", "repo", 1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "decode response")
+}
+
 func TestFindCoverageComment(t *testing.T) {
 	tests := []struct {
 		name       string


### PR DESCRIPTION
## Summary

Defense-in-depth hardening for the three VCS API clients (`github/`, `gitlab/`, `bitbucket/`) that post coverage comments. Four verified issues from a deep review, each with tests.

## Fixes

- **MED — GitLab token leak on cross-host redirect.** GitLab authenticates with the custom `PRIVATE-TOKEN` header. Go's `http.Client` strips `Authorization`/`Cookie` on a cross-host redirect but **not** custom headers, so a 3xx to an attacker host would forward the token. All three clients now install a `CheckRedirect` that rejects any redirect crossing to a different host (same-host/path redirects still allowed). Applied consistently across GitHub/GitLab/Bitbucket.
- **LOW — Unescaped path segments.** GitHub and Bitbucket interpolated `owner`/`repo`/`workspace` into API URL paths with raw `fmt.Sprintf`. These values can come from semi-trusted MCP/config input. Each segment is now `url.PathEscape`d (GitLab already did this).
- **LOW — Unbounded response bodies.** Every `io.ReadAll` / `json.Decode` of `resp.Body` across the three clients is now wrapped in `io.LimitReader(resp.Body, 5 MiB)`.
- **LOW — Bitbucket duplicate comments.** `FindCoverageComment` only scanned page 1, so an existing coverctl comment on page 2+ was missed and a duplicate was posted. It now follows the paginated `next` link (bounded by `maxCommentPages`) until the marker is found or pages are exhausted.

## Tests

- Cross-host redirect does not forward the token/credentials and returns an error (all three clients).
- Path-traversal/query characters (`../evil?injected=1`) are percent-escaped into a single path segment; no query leaks (GitHub, Bitbucket).
- An oversized response body is bounded (decode fails instead of buffering unbounded).
- Bitbucket follows `next` to locate an existing comment on page 2.

## Verification

`gofmt -l internal/` clean, `go build ./...`, `go test ./...`, and `golangci-lint run ./...` (0 issues) all green.

https://claude.ai/code/session_01QKTcmXFTKoTQr7mB3HCuHZ
