### PR TITLE
fix(mcp): harden server trust boundary

### DIFF
--- a/internal/mcp/config_ops.go
+++ b/internal/mcp/config_ops.go
@@ -1,0 +1,140 @@
+package mcp
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"go.klarlabs.de/coverctl/internal/application"
+	"go.klarlabs.de/coverctl/internal/infrastructure/config"
+	"go.klarlabs.de/coverctl/internal/pathutil"
+	"go.klarlabs.de/mcp"
+)
+
+// recoveryMiddleware returns the middleware chain applied to every MCP
+// request. mcp.Recover() converts a panic in any tool handler into an
+// internal-error response instead of tearing down the stdio session. Without
+// it a single panicking handler (a nil-map write, an out-of-range slice on a
+// malformed profile, etc.) would kill the process and drop every subsequent
+// call on the same long-lived stdio session — a one-shot DoS of the whole
+// server.
+func recoveryMiddleware() []mcp.Middleware {
+	return []mcp.Middleware{mcp.Recover()}
+}
+
+// defaultCheckRuntime is the server-side runtime ceiling applied to a check
+// invocation when the agent supplies no timeout. It mirrors the CLI's
+// --max-runtime default so an uncapped MCP check cannot pin the session.
+const defaultCheckRuntime = 15 * time.Minute
+
+// checkRuntimeLimit derives the runtime ceiling for a check call. A caller-
+// supplied Go-duration timeout overrides the default; an empty, unparseable,
+// or non-positive value falls back to defaultCheckRuntime so the agent surface
+// is never left uncapped.
+func checkRuntimeLimit(timeout string) time.Duration {
+	if timeout != "" {
+		if d, err := time.ParseDuration(timeout); err == nil && d > 0 {
+			return d
+		}
+	}
+	return defaultCheckRuntime
+}
+
+// Helper functions for config management
+
+// resolveConfigPath returns the config path to use.
+// If inputPath is specified and exists, use it.
+// If inputPath is specified but doesn't exist, try auto-detection.
+// If inputPath is empty, use server default.
+func (s *Server) resolveConfigPath(inputPath string) string {
+	// Use input path if provided
+	if inputPath != "" {
+		// If input path exists, use it directly
+		if _, err := os.Stat(inputPath); err == nil {
+			return inputPath
+		}
+		// Input path doesn't exist, try auto-detection
+		if foundPath, findErr := config.FindConfigFrom(""); findErr == nil {
+			return foundPath
+		}
+		// Auto-detection failed, return input path (will produce clear error)
+		return inputPath
+	}
+
+	// No input path, use server default
+	return s.config.ConfigPath
+}
+
+// applySuggestions applies the suggested thresholds to the config.
+func applySuggestions(cfg application.Config, suggestions []application.Suggestion) application.Config {
+	// Create a map for quick lookup
+	suggestedMins := make(map[string]float64)
+	for _, s := range suggestions {
+		suggestedMins[s.Domain] = s.SuggestedMin
+	}
+
+	// Apply suggestions to domains
+	for i := range cfg.Policy.Domains {
+		if min, ok := suggestedMins[cfg.Policy.Domains[i].Name]; ok {
+			minVal := min
+			cfg.Policy.Domains[i].Min = &minVal
+		}
+	}
+
+	return cfg
+}
+
+// backupConfig creates a backup of the existing config file.
+// Returns the backup path and any error.
+func backupConfig(configPath string) (string, error) {
+	// Check if file exists
+	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+		return "", err
+	}
+
+	// Read original content
+	content, err := os.ReadFile(configPath) // #nosec G304 - path from trusted config
+	if err != nil {
+		return "", fmt.Errorf("read config: %w", err)
+	}
+
+	// Create backup with timestamp
+	backupPath := configPath + ".backup"
+	if err := os.WriteFile(backupPath, content, 0o600); err != nil {
+		return "", fmt.Errorf("write backup: %w", err)
+	}
+
+	return backupPath, nil
+}
+
+// writeConfig writes the config to the specified path.
+//
+// The target is validated with the scoped validator (not the non-containment
+// pathutil.ValidatePath): a config WRITE that lowers coverage minimums must
+// stay inside the working directory. This rejects absolute paths and any
+// target resolved above cwd (e.g. a parent-dir .coverctl.yaml auto-discovered
+// via config.FindConfigFrom("")), so the gate cannot be relaxed out-of-tree.
+func writeConfig(configPath string, cfg application.Config) error {
+	root, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("resolve working directory: %w", err)
+	}
+
+	// Validate path stays within the working directory.
+	cleanPath, err := pathutil.ValidateScopedPath(configPath, root)
+	if err != nil {
+		return fmt.Errorf("invalid config path: %w", err)
+	}
+
+	file, err := os.Create(cleanPath) // #nosec G304 - path is validated above
+	if err != nil {
+		return fmt.Errorf("create config: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+
+	if err := config.Write(file, cfg); err != nil {
+		return fmt.Errorf("write config: %w", err)
+	}
+
+	return nil
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -80,7 +80,7 @@ func New(svc Service, cfg Config, version string) *Server {
 
 // Run starts the MCP server and blocks until the context is canceled.
 func (s *Server) Run(ctx context.Context) error {
-	return mcp.ServeStdio(ctx, s.server)
+	return mcp.ServeStdio(ctx, s.server, mcp.WithMiddleware(recoveryMiddleware()...))
 }
 
 // registerTools adds tool handlers to the server, gated by s.config.Mode.
@@ -216,7 +216,15 @@ func (s *Server) handleCheck(ctx context.Context, input CheckInput) (map[string]
 		opts.HistoryStore = &history.FileStore{Path: s.config.HistoryPath}
 	}
 
-	result, err := s.svc.CheckResult(ctx, opts)
+	// Cap the runtime of the (potentially unbounded) test run. On the agent
+	// surface the timeout is an optional caller-supplied param; without a
+	// server-side default a hung or pathological runner would hold the MCP
+	// session open indefinitely. Mirrors the CLI's --max-runtime ceiling and
+	// stays overridable via input.Timeout.
+	runCtx, cancel := context.WithTimeout(ctx, checkRuntimeLimit(input.Timeout))
+	defer cancel()
+
+	result, err := s.svc.CheckResult(runCtx, opts)
 	s.telemetry.RecordToolCall("check", time.Since(start), err, false)
 
 	if classified, ok := classifyRuntimeError(err); ok {
@@ -594,6 +602,19 @@ func (s *Server) handleSuggest(ctx context.Context, input SuggestInput) (map[str
 		return output, nil
 	}
 
+	// Gate the config-MUTATING write path behind CI mode. In agent (default)
+	// mode a writeConfig request is honored read-only: applySuggestions can
+	// lower a domain's minimum, so a prompt-injected agent could otherwise
+	// silently relax the coverage gate here and let a later `check` pass. The
+	// gate-lowering write requires an explicit --mode=ci.
+	if input.WriteConfig && s.config.Mode != ModeCI {
+		output["writeConfig"] = false
+		output["summary"] = fmt.Sprintf(
+			"Generated %d threshold suggestions using %s strategy; config NOT written: writeConfig requires --mode=ci (agent mode is read-only so suggestions cannot silently lower the coverage gate)",
+			len(result.Suggestions), strategy)
+		return output, nil
+	}
+
 	// Write suggested config if requested
 	if input.WriteConfig {
 		// Apply suggested thresholds to the config
@@ -896,92 +917,4 @@ func detectPRContextMCP(provider application.PRProvider, owner, repo string, prN
 	}
 
 	return owner, repo, prNumber
-}
-
-// Helper functions for config management
-
-// resolveConfigPath returns the config path to use.
-// If inputPath is specified and exists, use it.
-// If inputPath is specified but doesn't exist, try auto-detection.
-// If inputPath is empty, use server default.
-func (s *Server) resolveConfigPath(inputPath string) string {
-	// Use input path if provided
-	if inputPath != "" {
-		// If input path exists, use it directly
-		if _, err := os.Stat(inputPath); err == nil {
-			return inputPath
-		}
-		// Input path doesn't exist, try auto-detection
-		if foundPath, findErr := config.FindConfigFrom(""); findErr == nil {
-			return foundPath
-		}
-		// Auto-detection failed, return input path (will produce clear error)
-		return inputPath
-	}
-
-	// No input path, use server default
-	return s.config.ConfigPath
-}
-
-// applySuggestions applies the suggested thresholds to the config.
-func applySuggestions(cfg application.Config, suggestions []application.Suggestion) application.Config {
-	// Create a map for quick lookup
-	suggestedMins := make(map[string]float64)
-	for _, s := range suggestions {
-		suggestedMins[s.Domain] = s.SuggestedMin
-	}
-
-	// Apply suggestions to domains
-	for i := range cfg.Policy.Domains {
-		if min, ok := suggestedMins[cfg.Policy.Domains[i].Name]; ok {
-			minVal := min
-			cfg.Policy.Domains[i].Min = &minVal
-		}
-	}
-
-	return cfg
-}
-
-// backupConfig creates a backup of the existing config file.
-// Returns the backup path and any error.
-func backupConfig(configPath string) (string, error) {
-	// Check if file exists
-	if _, err := os.Stat(configPath); os.IsNotExist(err) {
-		return "", err
-	}
-
-	// Read original content
-	content, err := os.ReadFile(configPath) // #nosec G304 - path from trusted config
-	if err != nil {
-		return "", fmt.Errorf("read config: %w", err)
-	}
-
-	// Create backup with timestamp
-	backupPath := configPath + ".backup"
-	if err := os.WriteFile(backupPath, content, 0o600); err != nil {
-		return "", fmt.Errorf("write backup: %w", err)
-	}
-
-	return backupPath, nil
-}
-
-// writeConfig writes the config to the specified path.
-func writeConfig(configPath string, cfg application.Config) error {
-	// Validate path
-	cleanPath, err := pathutil.ValidatePath(configPath)
-	if err != nil {
-		return fmt.Errorf("invalid config path: %w", err)
-	}
-
-	file, err := os.Create(cleanPath) // #nosec G304 - path is validated above
-	if err != nil {
-		return fmt.Errorf("create config: %w", err)
-	}
-	defer func() { _ = file.Close() }()
-
-	if err := config.Write(file, cfg); err != nil {
-		return fmt.Errorf("write config: %w", err)
-	}
-
-	return nil
 }

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -21,6 +21,7 @@ type mockService struct {
 	checkResult      domain.Result
 	checkErr         error
 	checkOpts        application.CheckOptions // Captured options from last call
+	checkCtx         context.Context          // Captured context from last CheckResult call
 	enforceGatesErr  error                    // Returned by EnforceExtraGates
 	enforceGatesOpts application.CheckOptions // Captured options from last EnforceExtraGates call
 	reportResult     domain.Result
@@ -44,6 +45,7 @@ type mockService struct {
 
 func (m *mockService) CheckResult(ctx context.Context, opts application.CheckOptions) (domain.Result, error) {
 	m.checkOpts = opts // Capture the options for verification
+	m.checkCtx = ctx   // Capture the context to assert the runtime cap
 	return m.checkResult, m.checkErr
 }
 

--- a/internal/mcp/trust_test.go
+++ b/internal/mcp/trust_test.go
@@ -1,0 +1,255 @@
+package mcp
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"go.klarlabs.de/coverctl/internal/application"
+	"go.klarlabs.de/coverctl/internal/domain"
+	"go.klarlabs.de/mcp"
+	"go.klarlabs.de/mcp/protocol"
+)
+
+// TestRecoveryMiddleware_RecoversPanic asserts the middleware wired into Run
+// catches a panicking handler and turns it into an error instead of letting
+// the panic unwind and tear down the stdio session (a one-shot DoS of every
+// subsequent call). See FIX 1.
+func TestRecoveryMiddleware_RecoversPanic(t *testing.T) {
+	panicking := func(_ context.Context, _ *protocol.Request) (*protocol.Response, error) {
+		panic("handler boom")
+	}
+
+	// Compose the exact middleware Run applies, then invoke a panicking handler.
+	wrapped := mcp.Chain(recoveryMiddleware()...)(panicking)
+
+	// The call itself must not propagate the panic.
+	resp, err := func() (resp *protocol.Response, err error) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("panic escaped recovery middleware: %v", r)
+			}
+		}()
+		return wrapped(context.Background(), &protocol.Request{})
+	}()
+
+	if err == nil {
+		t.Fatal("expected recovered panic to surface as an error, got nil")
+	}
+	if resp != nil {
+		t.Errorf("expected nil response for a recovered panic, got %v", resp)
+	}
+	if !stringContains(err.Error(), "panic") {
+		t.Errorf("expected error to mention the panic, got %q", err.Error())
+	}
+}
+
+// TestHandleSuggest_WriteConfigReadOnlyInAgentMode asserts that a
+// suggest{writeConfig:true} call in agent (default) mode does NOT mutate the
+// config on disk and reports that a write requires CI mode. Without this a
+// prompt-injected agent could lower domain minimums so a later check passes.
+// See FIX 2.
+func TestHandleSuggest_WriteConfigReadOnlyInAgentMode(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+
+	configPath := ".coverctl.yaml"
+	original := "version: 1\npolicy:\n  default:\n    min: 90\n"
+	if err := os.WriteFile(configPath, []byte(original), 0o600); err != nil {
+		t.Fatalf("write seed config: %v", err)
+	}
+
+	lowered := 10.0
+	svc := &mockService{
+		suggestResult: application.SuggestResult{
+			Suggestions: []application.Suggestion{{Domain: "core", SuggestedMin: lowered}},
+			Config: application.Config{
+				Version: 1,
+				Policy: domain.Policy{
+					DefaultMin: 90,
+					Domains:    []domain.Domain{{Name: "core", Match: []string{"internal/core/*"}}},
+				},
+			},
+		},
+	}
+	server := New(svc, Config{Mode: ModeAgent, ConfigPath: configPath}, "test")
+
+	output, err := server.handleSuggest(context.Background(), SuggestInput{WriteConfig: true})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// The config file must be byte-for-byte unchanged.
+	after, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config after suggest: %v", err)
+	}
+	if string(after) != original {
+		t.Fatalf("agent-mode suggest modified the config:\nbefore=%q\nafter=%q", original, string(after))
+	}
+
+	// No backup should have been created (write path never entered).
+	if _, err := os.Stat(configPath + ".backup"); err == nil {
+		t.Error("expected no .backup file in agent mode")
+	}
+
+	if wrote, ok := output["writeConfig"].(bool); !ok || wrote {
+		t.Errorf("expected writeConfig=false in output, got %v", output["writeConfig"])
+	}
+	if _, ok := output["configPath"]; ok {
+		t.Errorf("expected no configPath in read-only output, got %v", output["configPath"])
+	}
+	summary, _ := output["summary"].(string)
+	if !stringContains(summary, "mode=ci") {
+		t.Errorf("expected summary to explain writeConfig requires CI mode, got %q", summary)
+	}
+}
+
+// TestHandleSuggest_WriteConfigAppliesInCIMode asserts the gate is real, not a
+// blanket block: in CI mode writeConfig still applies suggestions and backs up
+// the prior config. See FIX 2.
+func TestHandleSuggest_WriteConfigAppliesInCIMode(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+
+	configPath := ".coverctl.yaml"
+	original := "version: 1\npolicy:\n  default:\n    min: 90\n"
+	if err := os.WriteFile(configPath, []byte(original), 0o600); err != nil {
+		t.Fatalf("write seed config: %v", err)
+	}
+
+	lowered := 10.0
+	svc := &mockService{
+		suggestResult: application.SuggestResult{
+			Suggestions: []application.Suggestion{{Domain: "core", SuggestedMin: lowered}},
+			Config: application.Config{
+				Version: 1,
+				Policy: domain.Policy{
+					DefaultMin: 90,
+					Domains:    []domain.Domain{{Name: "core", Match: []string{"internal/core/*"}}},
+				},
+			},
+		},
+	}
+	server := New(svc, Config{Mode: ModeCI, ConfigPath: configPath}, "test")
+
+	output, err := server.handleSuggest(context.Background(), SuggestInput{WriteConfig: true})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cp, ok := output["configPath"].(string); !ok || cp != configPath {
+		t.Errorf("expected configPath=%q in output, got %v", configPath, output["configPath"])
+	}
+	if bp, ok := output["backupPath"].(string); !ok || bp == "" {
+		t.Errorf("expected a backupPath in output, got %v", output["backupPath"])
+	}
+	after, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config after suggest: %v", err)
+	}
+	if string(after) == original {
+		t.Error("expected CI-mode suggest to rewrite the config, but it was unchanged")
+	}
+	if _, err := os.Stat(configPath + ".backup"); err != nil {
+		t.Errorf("expected a .backup file in CI mode: %v", err)
+	}
+}
+
+// TestWriteConfig_RejectsOutOfScopePath asserts the config WRITE target is
+// scope-validated: absolute and parent-escaping paths are rejected, in-scope
+// relative paths succeed. See FIX 3.
+func TestWriteConfig_RejectsOutOfScopePath(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+
+	cfg := application.Config{
+		Version: 1,
+		Policy: domain.Policy{
+			DefaultMin: 80,
+			Domains:    []domain.Domain{{Name: "core", Match: []string{"internal/core/*"}}},
+		},
+	}
+
+	t.Run("rejects absolute path", func(t *testing.T) {
+		if err := writeConfig("/etc/coverctl-evil.yaml", cfg); err == nil {
+			t.Fatal("expected error for absolute path")
+		}
+		if _, err := os.Stat("/etc/coverctl-evil.yaml"); err == nil {
+			t.Error("absolute write was not blocked")
+		}
+	})
+
+	t.Run("rejects parent-escaping relative path", func(t *testing.T) {
+		if err := writeConfig("../escape-rel.yaml", cfg); err == nil {
+			t.Fatal("expected error for parent-escaping path")
+		}
+		if _, err := os.Stat(filepath.Join(tmpDir, "..", "escape-rel.yaml")); err == nil {
+			t.Error("parent-escaping write was not blocked")
+		}
+	})
+
+	t.Run("accepts in-scope relative path", func(t *testing.T) {
+		if err := writeConfig("in-scope.yaml", cfg); err != nil {
+			t.Fatalf("expected in-scope write to succeed, got %v", err)
+		}
+		if _, err := os.Stat(filepath.Join(tmpDir, "in-scope.yaml")); err != nil {
+			t.Errorf("expected in-scope file to be created: %v", err)
+		}
+	})
+}
+
+// TestCheckRuntimeLimit covers the runtime-cap derivation for the check
+// handler: default when unset/invalid, caller override when a valid duration
+// is supplied. See FIX 4.
+func TestCheckRuntimeLimit(t *testing.T) {
+	tests := []struct {
+		name    string
+		timeout string
+		want    time.Duration
+	}{
+		{"empty falls back to default", "", defaultCheckRuntime},
+		{"invalid falls back to default", "not-a-duration", defaultCheckRuntime},
+		{"zero falls back to default", "0s", defaultCheckRuntime},
+		{"negative falls back to default", "-5m", defaultCheckRuntime},
+		{"valid override", "90s", 90 * time.Second},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := checkRuntimeLimit(tt.timeout); got != tt.want {
+				t.Errorf("checkRuntimeLimit(%q) = %v, want %v", tt.timeout, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestHandleCheck_AppliesDefaultRuntimeCap asserts the check handler bounds the
+// service call with a deadline even when the agent supplies no timeout, so an
+// uncapped run cannot pin the MCP session. See FIX 4.
+func TestHandleCheck_AppliesDefaultRuntimeCap(t *testing.T) {
+	svc := &mockService{
+		checkResult: domain.Result{
+			Passed: true,
+			Domains: []domain.DomainResult{
+				{Domain: "core", Status: domain.StatusPass, Covered: 80, Total: 100},
+			},
+		},
+	}
+	server := New(svc, DefaultConfig(), "test")
+
+	if _, err := server.handleCheck(context.Background(), CheckInput{}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if svc.checkCtx == nil {
+		t.Fatal("expected CheckResult to receive a context")
+	}
+	deadline, ok := svc.checkCtx.Deadline()
+	if !ok {
+		t.Fatal("expected a runtime deadline on the check context, got none")
+	}
+	if remaining := time.Until(deadline); remaining <= 0 || remaining > defaultCheckRuntime+time.Minute {
+		t.Errorf("unexpected deadline window: %v (default %v)", remaining, defaultCheckRuntime)
+	}
+}


### PR DESCRIPTION
## Summary

Hardens the MCP server trust boundary against a prompt-injected agent and hung/panicking handlers. All changes are confined to `internal/mcp/`.

## Fixes

- **FIX 1 (MED) — panic recovery.** `Run` now serves with `mcp.WithMiddleware(mcp.Recover())`. Previously `mcp.NewServer` was constructed with no middleware, so a panic in any tool handler unwound and dropped the whole stdio session — a one-shot DoS of every subsequent call. A panicking handler now returns an internal error and the server survives.
- **FIX 2 (MED) — `suggest{writeConfig:true}` gated behind CI mode.** `suggest` is advertised in agent (default) mode and `applySuggestions` can lower domain minimums, so a prompt-injected agent could relax the coverage gate downward with no confirmation and let a later `check` pass. In agent mode `writeConfig` is now honored **read-only**: suggestions are returned, the config is not touched, and the response states that a write requires `--mode=ci`. The CI-mode write path is unchanged. (`init` is already CI-only advertised, so it is not agent-reachable.)
- **FIX 3 (LOW) — config WRITE path scope-validated.** `writeConfig` now validates the target with `pathutil.ValidateScopedPath(path, cwd)` instead of the non-containment `pathutil.ValidatePath`, rejecting absolute paths and any target resolved above cwd (e.g. a parent-dir `.coverctl.yaml` auto-discovered via `config.FindConfigFrom("")`).
- **FIX 4 (LOW) — uncapped `check` run.** `handleCheck` wraps the service call with a default 15m runtime ceiling (mirrors the CLI's `--max-runtime`) when the agent supplies no timeout, overridable via the `timeout` param, so an uncapped or hung runner cannot pin the session.

## Library API used

The `go.klarlabs.de/mcp` v1.20.0 recovery API is `mcp.Recover()` (a `Middleware`) applied via the `mcp.WithMiddleware(...)` **`ServeOption`** passed to `ServeStdio` — not a `NewServer` option. Wired accordingly in `Run`.

## Refactor note

Config/helper functions and the recovery middleware were extracted to a new `internal/mcp/config_ops.go` to keep `server.go` under the repo's architecture line-size ceiling (1000 lines).

## Verification

- `gofmt -l internal/` clean
- `go build ./...` clean
- `go test ./...` green (incl. new mcp trust tests + architecture ceiling)
- `golangci-lint run ./...` → 0 issues

## Tests added

- panic in a handler is recovered (no unwind, error returned)
- agent-mode `suggest{writeConfig:true}` does not modify the config and explains it requires CI mode; CI mode still writes + backs up
- out-of-scope config write targets (absolute / parent-escaping) are rejected; in-scope succeeds
- `check` applies a default runtime deadline; `checkRuntimeLimit` default/override table

https://claude.ai/code/session_01QKTcmXFTKoTQr7mB3HCuHZ
