### PR TITLE
fix(robustness): cap parser input, guard JaCoCo overflow, bound subprocess output & fix Windows path matching

### DIFF
--- a/internal/infrastructure/coverprofile/parser.go
+++ b/internal/infrastructure/coverprofile/parser.go
@@ -3,6 +3,7 @@ package coverprofile
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"os"
 	"strconv"
 	"strings"
@@ -10,6 +11,15 @@ import (
 	"go.klarlabs.de/coverctl/internal/application"
 	"go.klarlabs.de/coverctl/internal/domain"
 	"go.klarlabs.de/coverctl/internal/pathutil"
+)
+
+const (
+	// maxCoverageBytes caps the total bytes read from a coverage profile,
+	// bounding memory use against a crafted or corrupt input.
+	maxCoverageBytes = 256 << 20 // 256 MiB
+	// maxScanLineBytes caps a single scanned line so one unterminated line
+	// cannot allocate unbounded memory. Real profile lines are tiny.
+	maxScanLineBytes = 1 << 20 // 1 MiB
 )
 
 // Parser implements ProfileParser for Go coverage profile format.
@@ -79,7 +89,8 @@ func parseProfile(path string) (map[string]map[string]domain.CoverageStat, error
 	}
 	defer func() { _ = file.Close() }()
 
-	scanner := bufio.NewScanner(file)
+	scanner := bufio.NewScanner(io.LimitReader(file, maxCoverageBytes))
+	scanner.Buffer(make([]byte, 0, 64*1024), maxScanLineBytes)
 	lineStats := make(map[string]map[string]domain.CoverageStat)
 	lineNo := 0
 	for scanner.Scan() {

--- a/internal/infrastructure/coverprofile/parser_test.go
+++ b/internal/infrastructure/coverprofile/parser_test.go
@@ -3,6 +3,7 @@ package coverprofile
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -27,6 +28,26 @@ func TestParse(t *testing.T) {
 	}
 	if got := stats["internal/api/bar.go"]; got.Total != 1 || got.Covered != 1 {
 		t.Fatalf("unexpected api stats: %+v", got)
+	}
+}
+
+// TestParseOversizeLineBounded ensures a single pathologically long line
+// (no newline) is rejected by the capped scanner buffer rather than being
+// buffered unboundedly into memory.
+func TestParseOversizeLineBounded(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "coverage.out")
+
+	// A valid mode line, then a single line larger than maxScanLineBytes with
+	// no trailing newline.
+	oversize := strings.Repeat("A", maxScanLineBytes+1024)
+	content := "mode: atomic\n" + oversize
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if _, err := (Parser{}).Parse(path); err == nil {
+		t.Fatal("expected error for oversize line, got nil")
 	}
 }
 

--- a/internal/infrastructure/gotool/resolver.go
+++ b/internal/infrastructure/gotool/resolver.go
@@ -124,11 +124,14 @@ func goList(ctx context.Context, dir string, patterns ...string) ([]goPackage, e
 	args := append([]string{"list", "-json"}, patterns...)
 	cmd := exec.CommandContext(ctx, "go", args...) // #nosec G204 - patterns from trusted config, not user input
 	cmd.Dir = dir
-	out, err := cmd.Output()
-	if err != nil {
+	// Capture stdout into a bounded buffer so a runaway `go list` cannot
+	// exhaust memory. The ceiling is generous enough for any real repository.
+	out := &boundedBuffer{max: maxCmdOutputBytes}
+	cmd.Stdout = out
+	if err := cmd.Run(); err != nil {
 		return nil, err
 	}
-	dec := json.NewDecoder(bytesReader(out))
+	dec := json.NewDecoder(bytesReader(out.Bytes()))
 	pkgs := []goPackage{}
 	for {
 		var pkg goPackage

--- a/internal/infrastructure/gotool/runner.go
+++ b/internal/infrastructure/gotool/runner.go
@@ -1,6 +1,7 @@
 package gotool
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -12,6 +13,33 @@ import (
 	"go.klarlabs.de/coverctl/internal/domain"
 	"go.klarlabs.de/coverctl/internal/infrastructure/cmdrun"
 )
+
+// maxCmdOutputBytes caps stdout/stderr captured from a `go` subprocess (e.g.
+// `go list -json ./...`), bounding memory against a runaway child while
+// remaining generous enough for any realistic repository.
+const maxCmdOutputBytes = 256 << 20 // 256 MiB
+
+// boundedBuffer captures at most max bytes and silently discards the remainder.
+// Write always reports a full write so the child is never blocked on a full
+// pipe; only memory is bounded. Below max it behaves like a bytes.Buffer.
+type boundedBuffer struct {
+	buf bytes.Buffer
+	max int
+}
+
+func (b *boundedBuffer) Write(p []byte) (int, error) {
+	if remaining := b.max - b.buf.Len(); remaining > 0 {
+		if len(p) > remaining {
+			b.buf.Write(p[:remaining])
+		} else {
+			b.buf.Write(p)
+		}
+	}
+	return len(p), nil
+}
+
+// Bytes returns the captured (possibly truncated) output.
+func (b *boundedBuffer) Bytes() []byte { return b.buf.Bytes() }
 
 // Runner implements the CoverageRunner interface for Go projects.
 type Runner struct {
@@ -256,7 +284,13 @@ func runCommand(ctx context.Context, dir string, args []string) error {
 func runCommandOutput(ctx context.Context, dir string, args []string) ([]byte, error) {
 	cmd := exec.CommandContext(ctx, "go", args...)
 	cmd.Dir = dir
-	return cmd.CombinedOutput()
+	// Capture combined stdout+stderr into a single bounded buffer, matching
+	// CombinedOutput semantics while bounding memory.
+	out := &boundedBuffer{max: maxCmdOutputBytes}
+	cmd.Stdout = out
+	cmd.Stderr = out
+	err := cmd.Run()
+	return out.Bytes(), err
 }
 
 func runCommandEnv(ctx context.Context, dir string, env []string, cmdPath string, args []string) error {

--- a/internal/infrastructure/parsers/cobertura/parser.go
+++ b/internal/infrastructure/parsers/cobertura/parser.go
@@ -10,12 +10,17 @@ package cobertura
 import (
 	"encoding/xml"
 	"fmt"
+	"io"
 	"os"
 
 	"go.klarlabs.de/coverctl/internal/application"
 	"go.klarlabs.de/coverctl/internal/domain"
 	"go.klarlabs.de/coverctl/internal/pathutil"
 )
+
+// maxCoverageBytes caps the total bytes read from a coverage file, bounding
+// memory use against a crafted or corrupt input (unbounded-memory DoS guard).
+const maxCoverageBytes = 256 << 20 // 256 MiB
 
 // coverage represents the root Cobertura XML element.
 type coverage struct {
@@ -73,7 +78,7 @@ func (p *Parser) Parse(path string) (map[string]domain.CoverageStat, error) {
 	defer func() { _ = file.Close() }()
 
 	var cov coverage
-	if err := xml.NewDecoder(file).Decode(&cov); err != nil {
+	if err := xml.NewDecoder(io.LimitReader(file, maxCoverageBytes)).Decode(&cov); err != nil {
 		return nil, fmt.Errorf("decode cobertura xml: %w", err)
 	}
 

--- a/internal/infrastructure/parsers/jacoco/parser.go
+++ b/internal/infrastructure/parsers/jacoco/parser.go
@@ -9,12 +9,17 @@ package jacoco
 import (
 	"encoding/xml"
 	"fmt"
+	"io"
 	"os"
 
 	"go.klarlabs.de/coverctl/internal/application"
 	"go.klarlabs.de/coverctl/internal/domain"
 	"go.klarlabs.de/coverctl/internal/pathutil"
 )
+
+// maxCoverageBytes caps the total bytes read from a coverage file, bounding
+// memory use against a crafted or corrupt input (unbounded-memory DoS guard).
+const maxCoverageBytes = 256 << 20 // 256 MiB
 
 // report represents the root JaCoCo XML element.
 type report struct {
@@ -37,11 +42,11 @@ type sourceFile struct {
 }
 
 type line struct {
-	Nr int `xml:"nr,attr"` // Line number
-	Mi int `xml:"mi,attr"` // Missed instructions
-	Ci int `xml:"ci,attr"` // Covered instructions
-	Mb int `xml:"mb,attr"` // Missed branches
-	Cb int `xml:"cb,attr"` // Covered branches
+	Nr int   `xml:"nr,attr"` // Line number
+	Mi int64 `xml:"mi,attr"` // Missed instructions
+	Ci int64 `xml:"ci,attr"` // Covered instructions
+	Mb int64 `xml:"mb,attr"` // Missed branches
+	Cb int64 `xml:"cb,attr"` // Covered branches
 }
 
 type counter struct {
@@ -77,7 +82,7 @@ func (p *Parser) Parse(path string) (map[string]domain.CoverageStat, error) {
 	defer func() { _ = file.Close() }()
 
 	var rpt report
-	if err := xml.NewDecoder(file).Decode(&rpt); err != nil {
+	if err := xml.NewDecoder(io.LimitReader(file, maxCoverageBytes)).Decode(&rpt); err != nil {
 		return nil, fmt.Errorf("decode jacoco xml: %w", err)
 	}
 
@@ -89,6 +94,13 @@ func (p *Parser) Parse(path string) (map[string]domain.CoverageStat, error) {
 
 			var covered, total int
 			for _, ln := range sf.Lines {
+				// Reject negative counts (never emitted by JaCoCo). Using int64
+				// with a non-negative guard prevents Mi+Ci from wrapping
+				// negative on huge attribute values, which would silently drop
+				// an instrumented line and inflate the coverage ratio.
+				if ln.Mi < 0 || ln.Ci < 0 {
+					continue
+				}
 				// A line is instrumented if it has any instructions
 				if ln.Mi+ln.Ci > 0 {
 					total++

--- a/internal/infrastructure/parsers/jacoco/parser_test.go
+++ b/internal/infrastructure/parsers/jacoco/parser_test.go
@@ -136,6 +136,60 @@ func TestParser_ParseAll_Empty(t *testing.T) {
 	assert.Empty(t, stats)
 }
 
+// TestParser_Parse_HugeCountsDoNotOverflow ensures that very large mi/ci
+// attribute values are summed with int64 width so Mi+Ci never wraps negative
+// and silently drops an instrumented line (which would inflate coverage).
+func TestParser_Parse_HugeCountsDoNotOverflow(t *testing.T) {
+	// Values near int32 max: their sum overflows a 32-bit int but is fine as
+	// int64. A covered line (ci>0) must still count as covered.
+	content := `<?xml version="1.0"?>
+<report name="huge">
+  <package name="com/example">
+    <sourcefile name="Big.java">
+      <line nr="1" mi="2000000000" ci="2000000000" mb="0" cb="0"/>
+      <line nr="2" mi="2000000000" ci="0" mb="0" cb="0"/>
+    </sourcefile>
+  </package>
+</report>`
+
+	path := createTempFile(t, "jacoco.xml", content)
+
+	p := New()
+	stats, err := p.Parse(path)
+	require.NoError(t, err)
+
+	s := stats["com/example/Big.java"]
+	// Both lines are instrumented (mi+ci > 0); line 1 is covered (ci>0).
+	assert.Equal(t, 2, s.Total)
+	assert.Equal(t, 1, s.Covered)
+}
+
+// TestParser_Parse_NegativeCountsIgnored ensures a crafted profile with
+// negative mi/ci values cannot inflate coverage: such lines are skipped.
+func TestParser_Parse_NegativeCountsIgnored(t *testing.T) {
+	content := `<?xml version="1.0"?>
+<report name="negative">
+  <package name="com/example">
+    <sourcefile name="Bad.java">
+      <line nr="1" mi="-5" ci="-5" mb="0" cb="0"/>
+      <line nr="2" mi="0" ci="3" mb="0" cb="0"/>
+    </sourcefile>
+  </package>
+</report>`
+
+	path := createTempFile(t, "jacoco.xml", content)
+
+	p := New()
+	stats, err := p.Parse(path)
+	require.NoError(t, err)
+
+	s := stats["com/example/Bad.java"]
+	// Only line 2 is a valid instrumented+covered line; the negative line is
+	// dropped rather than counted.
+	assert.Equal(t, 1, s.Total)
+	assert.Equal(t, 1, s.Covered)
+}
+
 func createTempFile(t *testing.T, name, content string) string {
 	t.Helper()
 	tmpdir := t.TempDir()

--- a/internal/infrastructure/parsers/lcov/parser.go
+++ b/internal/infrastructure/parsers/lcov/parser.go
@@ -11,6 +11,7 @@ package lcov
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"os"
 	"strconv"
 	"strings"
@@ -18,6 +19,15 @@ import (
 	"go.klarlabs.de/coverctl/internal/application"
 	"go.klarlabs.de/coverctl/internal/domain"
 	"go.klarlabs.de/coverctl/internal/pathutil"
+)
+
+const (
+	// maxCoverageBytes caps the total bytes read from a coverage file,
+	// bounding memory use against a crafted or corrupt input.
+	maxCoverageBytes = 256 << 20 // 256 MiB
+	// maxScanLineBytes caps a single scanned line so one unterminated line
+	// cannot allocate unbounded memory. Real LCOV lines are tiny.
+	maxScanLineBytes = 1 << 20 // 1 MiB
 )
 
 // Parser implements ProfileParser for LCOV format.
@@ -47,7 +57,8 @@ func (p *Parser) Parse(path string) (map[string]domain.CoverageStat, error) {
 	defer func() { _ = file.Close() }()
 
 	stats := make(map[string]domain.CoverageStat)
-	scanner := bufio.NewScanner(file)
+	scanner := bufio.NewScanner(io.LimitReader(file, maxCoverageBytes))
+	scanner.Buffer(make([]byte, 0, 64*1024), maxScanLineBytes)
 
 	var currentFile string
 	var covered, total int

--- a/internal/infrastructure/paths/normalizer.go
+++ b/internal/infrastructure/paths/normalizer.go
@@ -2,6 +2,7 @@
 package paths
 
 import (
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -84,23 +85,32 @@ func ModuleRelativePath(path, moduleRoot string) string {
 }
 
 // IsExcluded checks if a file path matches any of the exclusion patterns.
+//
+// Both the file path and each pattern are normalized to forward slashes and
+// matched with path.Match (which always treats "/" as the separator) rather
+// than filepath.Match (whose separator is "\" on Windows). Coverage keys use
+// "/" on every platform, so this keeps exclusion behavior consistent and
+// avoids failing open on Windows.
 func IsExcluded(file string, patterns []string) bool {
 	if len(patterns) == 0 {
 		return false
 	}
+	slashFile := filepath.ToSlash(file)
 	for _, pattern := range patterns {
-		if ok, _ := filepath.Match(pattern, file); ok {
+		if ok, _ := path.Match(filepath.ToSlash(pattern), slashFile); ok {
 			return true
 		}
 	}
 	return false
 }
 
-// MatchesDirectory checks if a file belongs to a directory.
+// MatchesDirectory checks if a file belongs to a directory. Both sides are
+// normalized to forward slashes so directory attribution works when coverage
+// keys use "/" but the runtime separator is "\" (Windows).
 func MatchesDirectory(file, dir string) bool {
-	cleanFile := filepath.Clean(file)
-	cleanDir := filepath.Clean(dir)
-	return strings.HasPrefix(cleanFile, cleanDir+string(filepath.Separator)) || cleanFile == cleanDir
+	cleanFile := filepath.ToSlash(filepath.Clean(file))
+	cleanDir := filepath.ToSlash(filepath.Clean(dir))
+	return strings.HasPrefix(cleanFile, cleanDir+"/") || cleanFile == cleanDir
 }
 
 // MatchesAnyDirectory checks if a file belongs to any of the given directories.
@@ -116,20 +126,23 @@ func MatchesAnyDirectory(file string, dirs []string) bool {
 // MatchesAnyDirectoryWithRoot checks if a file belongs to any of the given directories,
 // also checking relative paths from the module root.
 func MatchesAnyDirectoryWithRoot(file string, dirs []string, moduleRoot string) bool {
-	cleanFile := filepath.Clean(file)
+	cleanFile := filepath.ToSlash(filepath.Clean(file))
 	for _, dir := range dirs {
-		cleanDir := filepath.Clean(dir)
-		if strings.HasPrefix(cleanFile, cleanDir+string(filepath.Separator)) || cleanFile == cleanDir {
+		nativeDir := filepath.Clean(dir)
+		cleanDir := filepath.ToSlash(nativeDir)
+		if strings.HasPrefix(cleanFile, cleanDir+"/") || cleanFile == cleanDir {
 			return true
 		}
 		if moduleRoot != "" {
-			relDir, err := filepath.Rel(moduleRoot, cleanDir)
+			// filepath.Rel needs native separators; slash-normalize only the
+			// result before comparing against the (slash) coverage key.
+			relDir, err := filepath.Rel(moduleRoot, nativeDir)
 			if err == nil {
-				relDir = filepath.Clean(relDir)
-				if relDir == "." {
+				relSlash := filepath.ToSlash(filepath.Clean(relDir))
+				if relSlash == "." {
 					return true
 				}
-				if strings.HasPrefix(cleanFile, relDir+string(filepath.Separator)) || cleanFile == relDir {
+				if strings.HasPrefix(cleanFile, relSlash+"/") || cleanFile == relSlash {
 					return true
 				}
 			}

--- a/internal/infrastructure/paths/normalizer_test.go
+++ b/internal/infrastructure/paths/normalizer_test.go
@@ -310,6 +310,22 @@ func TestIsExcluded(t *testing.T) {
 			patterns: []string{"[abc].go"},
 			expected: true,
 		},
+		{
+			// Coverage keys always use "/". A directory-scoped glob must match
+			// a forward-slash key regardless of the host OS separator.
+			name:     "forward-slash key matched by dir glob",
+			file:     "vendor/foo.go",
+			patterns: []string{"vendor/*"},
+			expected: true,
+		},
+		{
+			// "*" must not cross "/": a nested key is not matched by a
+			// single-segment glob.
+			name:     "single-segment glob does not cross slash",
+			file:     "vendor/nested/foo.go",
+			patterns: []string{"vendor/*"},
+			expected: false,
+		},
 	}
 
 	for _, tc := range tests {
@@ -380,6 +396,21 @@ func TestMatchesDirectory(t *testing.T) {
 			file:     ".",
 			dir:      "",
 			expected: true,
+		},
+		{
+			// Coverage keys use "/" on every platform; directory attribution
+			// must work against a forward-slash key even where the runtime
+			// separator differs (Windows).
+			name:     "forward-slash key in forward-slash dir",
+			file:     "internal/pkg/file.go",
+			dir:      "internal/pkg",
+			expected: true,
+		},
+		{
+			name:     "forward-slash key not in unrelated dir",
+			file:     "cmd/main.go",
+			dir:      "internal/pkg",
+			expected: false,
 		},
 	}
 

--- a/internal/infrastructure/runners/exec_util.go
+++ b/internal/infrastructure/runners/exec_util.go
@@ -1,0 +1,46 @@
+package runners
+
+import (
+	"bytes"
+	"time"
+)
+
+const (
+	// probeTimeout bounds tool-detection subprocesses (e.g. `--version`
+	// probes). Without a deadline a hung or unresponsive external tool would
+	// stall coverage collection indefinitely.
+	probeTimeout = 10 * time.Second
+
+	// maxProbeOutputBytes caps stdout captured from a probe/detection
+	// subprocess (e.g. `php -m`), bounding memory against a tool that emits
+	// unbounded output. Detection output is always tiny in practice.
+	maxProbeOutputBytes = 8 << 20 // 8 MiB
+
+	// maxCmdOutputBytes caps stdout captured from a data-producing
+	// subprocess (e.g. `xcrun llvm-cov export`). Generous but finite so a
+	// runaway child cannot exhaust memory.
+	maxCmdOutputBytes = 256 << 20 // 256 MiB
+)
+
+// boundedBuffer captures at most max bytes of output and silently discards the
+// remainder. Write always reports a full write so the child process is never
+// blocked on a full pipe; only memory is bounded. For normal-size output
+// (below max) behavior is identical to a bytes.Buffer.
+type boundedBuffer struct {
+	buf bytes.Buffer
+	max int
+}
+
+func (b *boundedBuffer) Write(p []byte) (int, error) {
+	if remaining := b.max - b.buf.Len(); remaining > 0 {
+		if len(p) > remaining {
+			b.buf.Write(p[:remaining])
+		} else {
+			b.buf.Write(p)
+		}
+	}
+	return len(p), nil
+}
+
+// Bytes returns the captured (possibly truncated) output.
+func (b *boundedBuffer) Bytes() []byte { return b.buf.Bytes() }

--- a/internal/infrastructure/runners/php.go
+++ b/internal/infrastructure/runners/php.go
@@ -78,7 +78,7 @@ func (r *PHPRunner) Run(ctx context.Context, opts application.RunOptions) (strin
 	}
 
 	// Build command args
-	args := r.buildArgs(opts, profile, phpunitPath)
+	args := r.buildArgs(ctx, opts, profile, phpunitPath)
 
 	execFn := r.Exec
 	if execFn == nil {
@@ -117,12 +117,18 @@ func (r *PHPRunner) detectPHPUnit(projectDir string) string {
 	return ""
 }
 
-// detectCoverageDriver detects whether PCOV or Xdebug is available as the coverage driver.
-func (r *PHPRunner) detectCoverageDriver() string {
+// detectCoverageDriver detects whether PCOV or Xdebug is available as the
+// coverage driver. The `php -m` probe runs under a short timeout derived from
+// ctx and its stdout is captured into a bounded buffer so a hung or noisy PHP
+// binary cannot stall detection or exhaust memory.
+func (r *PHPRunner) detectCoverageDriver(ctx context.Context) string {
 	// Check for PCOV first (faster, preferred for coverage)
-	cmd := exec.Command("php", "-m")
-	output, err := cmd.Output()
-	if err == nil && strings.Contains(string(output), "pcov") {
+	probeCtx, cancel := context.WithTimeout(ctx, probeTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(probeCtx, "php", "-m")
+	out := &boundedBuffer{max: maxProbeOutputBytes}
+	cmd.Stdout = out
+	if err := cmd.Run(); err == nil && strings.Contains(string(out.Bytes()), "pcov") {
 		return "pcov"
 	}
 
@@ -131,11 +137,11 @@ func (r *PHPRunner) detectCoverageDriver() string {
 }
 
 // buildArgs builds command line arguments for PHPUnit with coverage.
-func (r *PHPRunner) buildArgs(opts application.RunOptions, profile string, phpunitPath string) []string {
+func (r *PHPRunner) buildArgs(ctx context.Context, opts application.RunOptions, profile string, phpunitPath string) []string {
 	var args []string
 
 	// Add coverage driver flags
-	driver := r.detectCoverageDriver()
+	driver := r.detectCoverageDriver(ctx)
 	if driver == "pcov" {
 		args = append(args, "-dpcov.enabled=1")
 	}

--- a/internal/infrastructure/runners/python.go
+++ b/internal/infrastructure/runners/python.go
@@ -73,7 +73,7 @@ func (r *PythonRunner) Run(ctx context.Context, opts application.RunOptions) (st
 	}
 
 	// Detect which tool to use
-	tool := r.detectCoverageTool()
+	tool := r.detectCoverageTool(ctx)
 
 	var args []string
 	switch tool {
@@ -108,13 +108,17 @@ func (r *PythonRunner) RunIntegration(ctx context.Context, opts application.Inte
 	})
 }
 
-// detectCoverageTool determines which Python coverage tool is available.
-func (r *PythonRunner) detectCoverageTool() string {
+// detectCoverageTool determines which Python coverage tool is available. Each
+// probe subprocess runs under a short timeout derived from ctx so a hung
+// interpreter cannot stall detection indefinitely.
+func (r *PythonRunner) detectCoverageTool(ctx context.Context) string {
 	// Check for pytest-cov first (more common in modern projects)
 	if _, err := exec.LookPath("pytest"); err == nil {
 		// Check if pytest-cov is installed
-		cmd := exec.Command("python", "-c", "import pytest_cov")
-		if cmd.Run() == nil {
+		probeCtx, cancel := context.WithTimeout(ctx, probeTimeout)
+		err := exec.CommandContext(probeCtx, "python", "-c", "import pytest_cov").Run()
+		cancel()
+		if err == nil {
 			return "pytest-cov"
 		}
 	}
@@ -125,8 +129,9 @@ func (r *PythonRunner) detectCoverageTool() string {
 	}
 
 	// Try python -m coverage
-	cmd := exec.Command("python", "-m", "coverage", "--version")
-	if cmd.Run() == nil {
+	probeCtx, cancel := context.WithTimeout(ctx, probeTimeout)
+	defer cancel()
+	if exec.CommandContext(probeCtx, "python", "-m", "coverage", "--version").Run() == nil {
 		return "coverage"
 	}
 

--- a/internal/infrastructure/runners/rust.go
+++ b/internal/infrastructure/runners/rust.go
@@ -69,7 +69,7 @@ func (r *RustRunner) Run(ctx context.Context, opts application.RunOptions) (stri
 	}
 
 	// Detect which tool to use
-	tool := r.detectCoverageTool()
+	tool := r.detectCoverageTool(ctx)
 	args := r.buildArgs(tool, opts, profile)
 
 	execFn := r.Exec
@@ -93,17 +93,23 @@ func (r *RustRunner) RunIntegration(ctx context.Context, opts application.Integr
 	})
 }
 
-// detectCoverageTool determines which Rust coverage tool is available.
-func (r *RustRunner) detectCoverageTool() string {
+// detectCoverageTool determines which Rust coverage tool is available. Each
+// probe subprocess runs under a short timeout derived from ctx so a hung cargo
+// invocation cannot stall detection indefinitely.
+func (r *RustRunner) detectCoverageTool(ctx context.Context) string {
 	// Check for cargo-llvm-cov first (recommended for accuracy)
-	cmd := exec.Command("cargo", "llvm-cov", "--version")
-	if cmd.Run() == nil {
+	llvmCtx, cancelLlvm := context.WithTimeout(ctx, probeTimeout)
+	llvmErr := exec.CommandContext(llvmCtx, "cargo", "llvm-cov", "--version").Run()
+	cancelLlvm()
+	if llvmErr == nil {
 		return "llvm-cov"
 	}
 
 	// Check for cargo-tarpaulin
-	cmd = exec.Command("cargo", "tarpaulin", "--version")
-	if cmd.Run() == nil {
+	tarpCtx, cancelTarp := context.WithTimeout(ctx, probeTimeout)
+	tarpErr := exec.CommandContext(tarpCtx, "cargo", "tarpaulin", "--version").Run()
+	cancelTarp()
+	if tarpErr == nil {
 		return "tarpaulin"
 	}
 

--- a/internal/infrastructure/runners/swift.go
+++ b/internal/infrastructure/runners/swift.go
@@ -172,13 +172,20 @@ func runSwiftCommand(ctx context.Context, dir string, tool string, args []string
 	return cmdrun.Runner{Stdout: os.Stdout, Stderr: os.Stderr}.Exec(ctx, dir, tool, args)
 }
 
-// runSwiftCommandOutput executes a Swift or Xcode toolchain command and returns stdout.
+// runSwiftCommandOutput executes a Swift or Xcode toolchain command and returns
+// stdout captured into a bounded buffer so a runaway child cannot exhaust
+// memory. The ceiling is generous enough that any real LCOV export fits.
 func runSwiftCommandOutput(ctx context.Context, dir string, tool string, args []string) ([]byte, error) {
 	// #nosec G204 -- Tool is validated by caller (swift, xcrun)
 	cmd := exec.CommandContext(ctx, tool, args...)
 	if dir != "" {
 		cmd.Dir = dir
 	}
+	out := &boundedBuffer{max: maxCmdOutputBytes}
+	cmd.Stdout = out
 	cmd.Stderr = os.Stderr
-	return cmd.Output()
+	if err := cmd.Run(); err != nil {
+		return nil, err
+	}
+	return out.Bytes(), nil
 }


### PR DESCRIPTION
## Summary

A batch of verified **LOW-severity robustness fixes** from a deep review, scoped to the parser, runner, gotool, and path-normalization layers. No domain/gate, VCS, MCP, resolver, annotations, or config logic is touched.

## Fixes

1. **Parser input-size caps (unbounded-memory DoS).** Each coverage parser now wraps the opened file in `io.LimitReader(file, maxCoverageBytes)` (256 MiB) before decoding, and the line-scanning parsers cap their `bufio.Scanner` buffer (1 MiB/line). Affected: cobertura, jacoco, lcov, and the Go coverprofile parser.

2. **JaCoCo integer overflow (silent mis-parse).** `mi`/`ci` are now parsed as `int64` with a non-negative guard, so `Mi+Ci` can no longer wrap negative on huge attribute values and silently drop an instrumented line (which would inflate the coverage ratio). Negative counts are skipped.

3. **Version-probe subprocesses now honor context/timeout.** Tool-detection probes in `python.go`, `rust.go`, and `php.go` run via `exec.CommandContext` under a 10s timeout derived from the caller `ctx`, so a hung external tool cannot stall collection. Detect helpers were threaded a `ctx` parameter (contained to the runners package).

4. **Bounded child-process output.** `go list -json ./...` (gotool/resolver), `go` `CombinedOutput` (gotool/runner), `xcrun llvm-cov export` (swift), and `php -m` (php) now capture stdout/stderr into a bounded buffer with a finite ceiling (256 MiB for data-producing commands, 8 MiB for detection probes). Behavior is identical for normal-size output.

5. **Cross-platform path matching (fail-open on Windows).** `IsExcluded` now normalizes both sides with `filepath.ToSlash` and matches with `path.Match` (always `/`-separated) instead of `filepath.Match` (uses `\` on Windows). `MatchesDirectory` and `MatchesAnyDirectoryWithRoot` build prefixes with `/` after slash-normalizing, so exclusion and directory attribution work against forward-slash coverage keys on Windows.

## Tests

- JaCoCo: huge (int32-overflowing) and negative `mi`/`ci` counts do not inflate coverage.
- Coverprofile: an oversize single line is rejected by the capped scanner rather than buffered unboundedly.
- Paths: `IsExcluded` and `MatchesDirectory` work against forward-slash keys, and single-segment globs do not cross `/`.

## Verification

- `gofmt -l internal/` — clean
- `go build ./...` — ok
- `go test ./...` — all packages pass
- `golangci-lint run ./...` — 0 issues

https://claude.ai/code/session_01QKTcmXFTKoTQr7mB3HCuHZ
