### PR TITLE
feat(mcp): advertise output schemas for data tools

### DIFF
--- a/internal/mcp/output_schema_test.go
+++ b/internal/mcp/output_schema_test.go
@@ -1,0 +1,40 @@
+package mcp
+
+import (
+	"testing"
+
+	"go.klarlabs.de/mcp/schema"
+)
+
+// TestOutputSchemasGenerate guards every type advertised via
+// ToolBuilder.OutputSchema. OutputSchema runs schema.Generate at registration
+// time and, if generation errors, silently drops the tool from the server.
+// This test fails loudly instead, so a future change to an output struct (or a
+// nested domain/application type) that breaks schema generation is caught in CI
+// rather than by a tool mysteriously disappearing from tools/list.
+func TestOutputSchemasGenerate(t *testing.T) {
+	tests := []struct {
+		name string
+		typ  any
+	}{
+		{"check/report (ToolOutput)", ToolOutput{}},
+		{"suggest (SuggestOutput)", SuggestOutput{}},
+		{"debt (DebtOutput)", DebtOutput{}},
+		{"compare (CompareOutput)", CompareOutput{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, err := schema.Generate(tt.typ)
+			if err != nil {
+				t.Fatalf("schema.Generate(%T) returned error: %v", tt.typ, err)
+			}
+			if s == nil {
+				t.Fatalf("schema.Generate(%T) returned nil schema", tt.typ)
+			}
+			if s.Type != "object" {
+				t.Fatalf("schema.Generate(%T) type = %q, want object", tt.typ, s.Type)
+			}
+		})
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -99,14 +99,17 @@ func (s *Server) registerTools() {
 
 	s.server.Tool("check").
 		Description("Run the project's test suite with coverage and enforce per-domain policy thresholds defined in .coverctl.yaml. Auto-detects the language and invokes the appropriate test runner (go test, pytest, npm test, mvn, gradle, cargo, dotnet, etc.). Returns per-domain pass/fail, file-level coverage, and warnings. Exit-equivalent: passed=true on success, passed=false on policy violation or runner error.").
+		OutputSchema(ToolOutput{}).
 		Handler(s.handleCheck)
 
 	s.server.Tool("suggest").
 		Description("Analyze current coverage and suggest threshold values for each domain. Strategies: 'current' (set thresholds slightly below current observed coverage to lock in the status quo), 'aggressive' (set targets above current to push improvement), 'conservative' (small incremental gains). Use writeConfig=true to apply suggestions; coverctl backs up the existing file first.").
+		OutputSchema(SuggestOutput{}).
 		Handler(s.handleSuggest)
 
 	s.server.Tool("debt").
 		Description("Compute coverage debt: the gap between current coverage and required thresholds, ranked per domain and per file. Returns a health score (0-100) and the items contributing the most debt. Use this to direct test-writing effort to the highest-impact gaps.").
+		OutputSchema(DebtOutput{}).
 		Handler(s.handleDebt)
 
 	if agent {
@@ -119,6 +122,7 @@ func (s *Server) registerTools() {
 
 	s.server.Tool("report").
 		Description("Analyze an existing coverage profile without re-running tests. Supports Go cover profiles, LCOV (info), Cobertura (XML), and JaCoCo (XML); format auto-detected from file content. Use when a profile is already on disk from a prior CI run or a separate test invocation.").
+		OutputSchema(ToolOutput{}).
 		Handler(s.handleReport)
 
 	s.server.Tool("record").
@@ -131,6 +135,7 @@ func (s *Server) registerTools() {
 
 	s.server.Tool("compare").
 		Description("Diff coverage between two profiles (base vs head). Returns overall delta, files whose coverage improved, files whose coverage regressed, and domain-level deltas. Use to evaluate whether a code change improved or worsened coverage before committing.").
+		OutputSchema(CompareOutput{}).
 		Handler(s.handleCompare)
 
 	s.server.Tool("pr-comment").

--- a/internal/mcp/types.go
+++ b/internal/mcp/types.go
@@ -149,14 +149,74 @@ type InitInput struct {
 	Force      bool   `json:"force,omitempty" jsonschema:"description=Overwrite existing config file if it exists"`
 }
 
-// ToolOutput represents the common output structure for tools.
+// ToolOutput is the structured-output schema shared by the check and report
+// tools. It mirrors the response map their handlers emit — the coverage
+// summary plus, when the caller truncates output, the pagination cursors, and
+// the shared error-response envelope (error/error_code/remediation). Advertised
+// via ToolBuilder.OutputSchema so tools/call responses carry typed
+// structuredContent alongside the JSON text block.
 type ToolOutput struct {
-	Passed   bool                  `json:"passed"`
-	Summary  string                `json:"summary,omitempty"`
-	Domains  []domain.DomainResult `json:"domains,omitempty"`
-	Files    []domain.FileResult   `json:"files,omitempty"`
-	Warnings []string              `json:"warnings,omitempty"`
-	Error    string                `json:"error,omitempty"`
+	Passed            bool                  `json:"passed"`
+	Summary           string                `json:"summary,omitempty"`
+	Domains           []domain.DomainResult `json:"domains,omitempty"`
+	Files             []domain.FileResult   `json:"files,omitempty"`
+	Warnings          []string              `json:"warnings,omitempty"`
+	DomainsNextCursor string                `json:"domainsNextCursor,omitempty"`
+	FilesNextCursor   string                `json:"filesNextCursor,omitempty"`
+	Error             string                `json:"error,omitempty"`
+	ErrorCode         string                `json:"error_code,omitempty"`
+	Remediation       string                `json:"remediation,omitempty"`
+}
+
+// SuggestOutput is the structured-output schema for the suggest tool: the
+// generated threshold suggestions plus the write-config bookkeeping and shared
+// error envelope its handler can emit.
+type SuggestOutput struct {
+	Passed      bool                     `json:"passed"`
+	Suggestions []application.Suggestion `json:"suggestions,omitempty"`
+	Summary     string                   `json:"summary,omitempty"`
+	WriteConfig bool                     `json:"writeConfig,omitempty"`
+	ConfigPath  string                   `json:"configPath,omitempty"`
+	BackupPath  string                   `json:"backupPath,omitempty"`
+	Error       string                   `json:"error,omitempty"`
+	ErrorCode   string                   `json:"error_code,omitempty"`
+	Remediation string                   `json:"remediation,omitempty"`
+}
+
+// DebtOutput is the structured-output schema for the debt tool: the ranked
+// debt items, the health/debt totals, an optional pagination cursor, and the
+// shared error envelope.
+type DebtOutput struct {
+	Passed          bool                   `json:"passed"`
+	Items           []application.DebtItem `json:"items,omitempty"`
+	TotalDebt       float64                `json:"totalDebt"`
+	TotalLines      int                    `json:"totalLines"`
+	HealthScore     float64                `json:"healthScore"`
+	ItemsNextCursor string                 `json:"itemsNextCursor,omitempty"`
+	Summary         string                 `json:"summary,omitempty"`
+	Error           string                 `json:"error,omitempty"`
+	ErrorCode       string                 `json:"error_code,omitempty"`
+	Remediation     string                 `json:"remediation,omitempty"`
+}
+
+// CompareOutput is the structured-output schema for the compare tool: overall
+// and per-file/per-domain coverage deltas, optional pagination cursors, and the
+// shared error envelope.
+type CompareOutput struct {
+	Passed              bool                    `json:"passed"`
+	BaseOverall         float64                 `json:"baseOverall"`
+	HeadOverall         float64                 `json:"headOverall"`
+	Delta               float64                 `json:"delta"`
+	Improved            []application.FileDelta `json:"improved,omitempty"`
+	Regressed           []application.FileDelta `json:"regressed,omitempty"`
+	Unchanged           int                     `json:"unchanged"`
+	DomainDeltas        map[string]float64      `json:"domainDeltas,omitempty"`
+	ImprovedNextCursor  string                  `json:"improvedNextCursor,omitempty"`
+	RegressedNextCursor string                  `json:"regressedNextCursor,omitempty"`
+	Summary             string                  `json:"summary,omitempty"`
+	Error               string                  `json:"error,omitempty"`
+	ErrorCode           string                  `json:"error_code,omitempty"`
+	Remediation         string                  `json:"remediation,omitempty"`
 }
 
 // coalesce returns value if non-empty, otherwise fallback.


### PR DESCRIPTION
## What

Adopt mcp-go's structured-output support (`OutputSchema` + `structuredContent`)
for coverctl's coverage-data MCP tools. `tools/call` responses now carry typed
`structuredContent` alongside the existing JSON text block, per the MCP
`outputSchema` contract — so clients can consume coverage results as typed data
without re-parsing the text block.

## How

mcp-go promotes a handler's JSON-object response to `structuredContent`
automatically whenever the tool declares an output schema. Each converted tool
gains `.OutputSchema(T{})`; handlers, response text, and behavior are otherwise
unchanged.

## Converted tools (data-returning)

| Tool | Output schema type |
|------|--------------------|
| `check`   | `ToolOutput` |
| `report`  | `ToolOutput` (same shape as check) |
| `suggest` | `SuggestOutput` |
| `debt`    | `DebtOutput` |
| `compare` | `CompareOutput` |

The schema types (package-scope, in `internal/mcp/types.go`) each mirror the
exact keys their handler emits — including the pagination cursors and the
shared error envelope (`error`/`error_code`/`remediation`) — so the advertised
closed schema covers both success and failure responses. The previously unused
`ToolOutput` type was extended to serve as the check/report schema.

## Skipped (not genuine structured-data objects)

- **`badge`** — returns an SVG string, not a data object.
- **`record`** — mutation (appends to history); returns only status + warnings.
- **`init`** — mutation (writes `.coverctl.yaml`); returns status + paths.
- **`pr-comment`** — mutation (posts a PR/MR comment); body is markdown text.

## Guard test

`internal/mcp/output_schema_test.go` calls `schema.Generate` on every advertised
type and asserts no error + object type. `OutputSchema` runs `schema.Generate`
at registration and **silently drops the tool** on error, so this test fails
loudly in CI instead of a tool quietly vanishing from `tools/list`.

## Note on return types

Handlers keep returning `map[string]any`: their success and error paths funnel
through shared helpers (`rejectionResponse`, `errorResponse`,
`classifyRuntimeError`) that are also used by the non-converted tools, so the
typed structs serve as the single schema source rather than the handler return
type. structuredContent is still a proper JSON object as the spec requires.

## Verification

- `gofmt -l` clean on changed files
- `go build ./...`, `go vet ./internal/mcp/` clean
- `go test ./...` passes
- `golangci-lint run ./internal/mcp/` — 0 issues
- Confirmed via test that all five tools register with a non-nil outputSchema (none dropped)

https://claude.ai/code/session_01LCyhyAffdzBmzG3yPPqzTT