### PR TITLE
chore(release): publish the brew artefact to felixgeelhaar/homebrew-tap

### DIFF
--- a/scripts/update-homebrew-tap.sh
+++ b/scripts/update-homebrew-tap.sh
@@ -36,14 +36,14 @@ CRED_FILE=$(mktemp)
 trap 'rm -f "$CRED_FILE"' EXIT
 echo "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com" > "$CRED_FILE"
 git config --global credential.helper "store --file=${CRED_FILE}"
-git clone "https://github.com/klarlabs-studio/homebrew-tap.git" tap
+git clone "https://github.com/felixgeelhaar/homebrew-tap.git" tap
 cd tap
 
 # Generate updated formula
 echo "Generating formula..."
 cat > Formula/coverctl.rb << EOF
 # Homebrew formula for Coverctl
-# To install: brew tap klarlabs-studio/tap && brew install coverctl
+# To install: brew tap felixgeelhaar/tap && brew install coverctl
 class Coverctl < Formula
   desc "Declarative, domain-aware coverage enforcement for any language"
   homepage "https://github.com/klarlabs-studio/coverctl"


### PR DESCRIPTION
The klarlabs projects were split across **two Homebrew taps**:

| Tap | Entries | Repos |
|---|---|---|
| `felixgeelhaar/homebrew-tap` | **24** (21 formulae + 3 casks) | warden, tokenops, plus nox, roady, preflight… |
| `klarlabs-studio/homebrew-tap` | **4** | briefkasten, mnemos, scout, coverctl |

That split forced **two credentials**, because a fine-grained PAT has exactly one resource owner and the two taps have different owners — one personal, one org. Keeping both means two tokens to rotate and two places to get it wrong, which is the failure that produced a 401 on warden v0.19.0 and a 403 on v0.20.0.

Consolidating on the larger tap gives one token, one rotation point, and one `brew tap` for users.

## Scope

Only the tap target changes. The token env var and secret name are untouched — the org-level `HOMEBREW_TAP_TOKEN` is already scoped to `felixgeelhaar/homebrew-tap` with `contents:write`, so this repo's next release will authenticate correctly. Without this change it would not: the token cannot write to the org tap.

## Before the next release of mnemos

`felixgeelhaar/homebrew-tap` still contains a stale **`Formula/mnemos.rb` @ 0.18.0** from before mnemos moved. mnemos now ships as a **Cask** (0.116.2), so publishing there would leave a formula *and* a cask both named `mnemos` in one tap, making `brew install mnemos` ambiguous. That stale formula needs deleting — tracked separately, not blocking this PR.

`Formula/coverctl.rb` @ 1.17.0 and `Formula/scout.rb` @ 1.10.0 are also stale but the same type, so the next release simply overwrites them.

## User-facing

Anyone who ran `brew tap klarlabs-studio/homebrew-tap` keeps resolving the old formula until they re-tap. The org tap should get a deprecation note or be archived once all four have released from the new location.
