### PR TITLE
chore(release): publish the brew artefact to the klarlabs-studio tap

### DIFF
--- a/scripts/update-homebrew-tap.sh
+++ b/scripts/update-homebrew-tap.sh
@@ -36,14 +36,14 @@ CRED_FILE=$(mktemp)
 trap 'rm -f "$CRED_FILE"' EXIT
 echo "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com" > "$CRED_FILE"
 git config --global credential.helper "store --file=${CRED_FILE}"
-git clone "https://github.com/felixgeelhaar/homebrew-tap.git" tap
+git clone "https://github.com/klarlabs-studio/homebrew-tap.git" tap
 cd tap
 
 # Generate updated formula
 echo "Generating formula..."
 cat > Formula/coverctl.rb << EOF
 # Homebrew formula for Coverctl
-# To install: brew tap felixgeelhaar/tap && brew install coverctl
+# To install: brew tap klarlabs-studio/tap && brew install coverctl
 class Coverctl < Formula
   desc "Declarative, domain-aware coverage enforcement for any language"
   homepage "https://github.com/klarlabs-studio/coverctl"


### PR DESCRIPTION
**Destination and credential must share a resource owner.** A fine-grained PAT has exactly one, and the org secret `HOMEBREW_TAP_TOKEN` is now owned by `klarlabs-studio`.

This repo still pointed at `felixgeelhaar/homebrew-tap` — a **personally-owned** repo — so its next release would have failed:

```
403 Resource not accessible by personal access token
```

## Verified, not assumed

A write probe against both taps, using the actual org secret from inside Actions, with a request that cannot modify anything (`PUT` with a deliberately invalid blob sha):

```
klarlabs-studio/homebrew-tap -> HTTP 409 : WRITE GRANTED
felixgeelhaar/homebrew-tap   -> HTTP 403 : NO WRITE GRANT
```

## Fleet direction

`klarlabs-studio` repos publish to the `klarlabs-studio` tap; the personal projects keep their own tap and their own personally-owned token. Ownership of the **destination** now matches ownership of the **code** and of the **credential** — which is the property whose absence produced a 401 on warden v0.19.0, a 403 on v0.20.0, and a 403 on briefkasten v0.31.0 this morning.

## Note for users

The formula/cask in `felixgeelhaar/homebrew-tap` stops being updated. Anyone installed from that tap silently pins to the last version published there. The stale copies want deleting once the first release lands in the org tap — tracked separately.
