### PR TITLE
fix: accept in-root absolute paths, stamp version, warn on unmatched packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,18 @@ exclude:
 
 Per-domain enforcement is the point: overall coverage hides regressions in critical paths. coverctl evaluates each domain against its own minimum and fails the build if any domain falls below.
 
+#### Why these numbers differ from `go test ./...`
+
+coverctl runs tests with `-coverpkg` spanning the configured domains, so a package is credited for the tests of *other* packages that exercise it. Plain `go test ./...` credits only a package's own test files. The same code therefore gets two legitimate numbers, and coverctl's is the higher, more accurate one:
+
+| package | `go test ./...` | coverctl |
+|---|---|---|
+| a package exercised only through its callers | 0.0% | 80% |
+
+If a package looks untested under `go test`, check it here before writing tests for it — a helper called from everywhere but tested nowhere directly will read as 0% and be fully covered in practice. The reverse case is real too: a package can look fine in aggregate while one file inside it has no tests at all, which is what `files:` rules exist for.
+
+Note that `--from-profile` reports whatever the supplied profile measured. If that profile came from a plain `go test ./...`, the numbers are per-package and the distinction above does not apply.
+
 ### Advanced
 
 ```yaml

--- a/internal/application/check_handler.go
+++ b/internal/application/check_handler.go
@@ -165,6 +165,8 @@ func (h *CheckHandler) CheckResult(ctx context.Context, opts CheckOptions) (doma
 
 	result := domain.Evaluate(policy, domainCoverage)
 	result.Warnings = domainOverlapWarnings(domainDirs)
+	result.Warnings = append(result.Warnings,
+		unmatchedPackageWarnings(filteredCoverage, domainDirs, cfg.Exclude, moduleRoot, modulePath, annotations)...)
 	if len(fromProfileWarnings) > 0 {
 		result.Warnings = append(result.Warnings, fromProfileWarnings...)
 	}

--- a/internal/application/report_handler.go
+++ b/internal/application/report_handler.go
@@ -100,6 +100,8 @@ func (h *ReportHandler) ReportResult(ctx context.Context, opts ReportOptions) (d
 
 	result := domain.Evaluate(policy, domainCoverage)
 	result.Warnings = domainOverlapWarnings(domainDirs)
+	result.Warnings = append(result.Warnings,
+		unmatchedPackageWarnings(filteredCoverage, domainDirs, cfg.Exclude, moduleRoot, modulePath, annotations)...)
 
 	fileResults, filesPassed := evaluateFileRules(filteredCoverage, cfg.Files, cfg.Exclude, annotations)
 	result.Files = fileResults

--- a/internal/application/service.go
+++ b/internal/application/service.go
@@ -271,6 +271,8 @@ func (s *Service) CheckResult(ctx context.Context, opts CheckOptions) (domain.Re
 	}
 	result := domain.Evaluate(policy, domainCoverage)
 	result.Warnings = domainOverlapWarnings(domainDirs)
+	result.Warnings = append(result.Warnings,
+		unmatchedPackageWarnings(filteredCoverage, domainDirs, cfg.Exclude, moduleRoot, modulePath, annotations)...)
 	if len(fromProfileWarnings) > 0 {
 		result.Warnings = append(result.Warnings, fromProfileWarnings...)
 	}
@@ -452,6 +454,8 @@ func (s *Service) ReportResult(ctx context.Context, opts ReportOptions) (domain.
 	}
 	result := domain.Evaluate(policy, domainCoverage)
 	result.Warnings = domainOverlapWarnings(domainDirs)
+	result.Warnings = append(result.Warnings,
+		unmatchedPackageWarnings(filteredCoverage, domainDirs, cfg.Exclude, moduleRoot, modulePath, annotations)...)
 	fileResults, filesPassed := evaluateFileRules(filteredCoverage, cfg.Files, cfg.Exclude, annotations)
 	result.Files = fileResults
 	if !filesPassed {
@@ -799,26 +803,6 @@ func (s *Service) loadAnnotations(ctx context.Context, cfg Config, moduleRoot st
 		paths = append(paths, file)
 	}
 	return s.AnnotationScanner.Scan(ctx, moduleRoot, paths)
-}
-
-func domainOverlapWarnings(domainDirs map[string][]string) []string {
-	dirOwners := make(map[string][]string, len(domainDirs))
-	for name, dirs := range domainDirs {
-		for _, dir := range dirs {
-			cleanDir := filepath.Clean(dir)
-			dirOwners[cleanDir] = append(dirOwners[cleanDir], name)
-		}
-	}
-	var warnings []string
-	for dir, owners := range dirOwners {
-		if len(owners) <= 1 {
-			continue
-		}
-		sort.Strings(owners)
-		warnings = append(warnings, fmt.Sprintf("directory %s belongs to %s domains", dir, strings.Join(owners, ", ")))
-	}
-	sort.Strings(warnings)
-	return warnings
 }
 
 // buildDomainExcludes creates a map of domain name to exclude patterns from domain configs.

--- a/internal/application/warnings.go
+++ b/internal/application/warnings.go
@@ -1,0 +1,113 @@
+package application
+
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"go.klarlabs.de/coverctl/internal/domain"
+)
+
+// Warnings surface configuration problems that are not policy failures: the
+// check still passes, but something about the domain layout means the result
+// says less than it appears to.
+
+func domainOverlapWarnings(domainDirs map[string][]string) []string {
+	dirOwners := make(map[string][]string, len(domainDirs))
+	for name, dirs := range domainDirs {
+		for _, dir := range dirs {
+			cleanDir := filepath.Clean(dir)
+			dirOwners[cleanDir] = append(dirOwners[cleanDir], name)
+		}
+	}
+	var warnings []string
+	for dir, owners := range dirOwners {
+		if len(owners) <= 1 {
+			continue
+		}
+		sort.Strings(owners)
+		warnings = append(warnings, fmt.Sprintf("directory %s belongs to %s domains", dir, strings.Join(owners, ", ")))
+	}
+	sort.Strings(warnings)
+	return warnings
+}
+
+// maxUnmatchedDirsReported bounds the unmatched-package warning so a project
+// that has only just adopted domains gets a usable hint rather than a wall.
+const maxUnmatchedDirsReported = 5
+
+// unmatchedPackageWarnings reports directories that carry coverage but match no
+// domain, so no minimum applies to them.
+//
+// An overlapping directory is loudly warned about while a directory owned by
+// NO domain is silent — yet the silent case is the dangerous one. An
+// overlapping package is measured twice; an unmatched package is measured
+// never, and a newly added package is unmatched by default. It contributes to
+// no domain, so the table stays green while nothing enforces it.
+//
+// The matching logic deliberately mirrors AggregateByDomainWithExcludes: a file
+// this reports as unmatched is exactly a file that contributed to no domain
+// there. Anything the aggregation skips outright — excluded paths, ignore
+// annotations — is skipped here too, because those are deliberate omissions
+// rather than gaps.
+func unmatchedPackageWarnings(files map[string]domain.CoverageStat, domainDirs map[string][]string, exclude []string, moduleRoot, modulePath string, annotations map[string]Annotation) []string {
+	if len(domainDirs) == 0 {
+		return nil // no domains configured at all: not this warning's business
+	}
+
+	type dirStat struct {
+		files int
+		stmts int
+	}
+	unmatched := make(map[string]*dirStat)
+
+	for file, stat := range files {
+		normalized := normalizeCoverageFile(file, modulePath, moduleRoot)
+		relPath := moduleRelativePath(normalized, moduleRoot)
+		if excluded(relPath, exclude) {
+			continue
+		}
+		if ann, ok := annotations[filepath.ToSlash(relPath)]; ok && (ann.Ignore || ann.Domain != "") {
+			continue
+		}
+		matched := false
+		for _, dirs := range domainDirs {
+			if matchesAnyDir(normalized, dirs, moduleRoot) {
+				matched = true
+				break
+			}
+		}
+		if matched {
+			continue
+		}
+		dir := filepath.ToSlash(filepath.Dir(relPath))
+		if unmatched[dir] == nil {
+			unmatched[dir] = &dirStat{}
+		}
+		unmatched[dir].files++
+		unmatched[dir].stmts += stat.Total
+	}
+	if len(unmatched) == 0 {
+		return nil
+	}
+
+	dirs := make([]string, 0, len(unmatched))
+	for dir := range unmatched {
+		dirs = append(dirs, dir)
+	}
+	sort.Strings(dirs)
+
+	var warnings []string
+	for i, dir := range dirs {
+		if i == maxUnmatchedDirsReported {
+			warnings = append(warnings, fmt.Sprintf("... and %d more directory/ies matched by no domain", len(dirs)-i))
+			break
+		}
+		s := unmatched[dir]
+		warnings = append(warnings, fmt.Sprintf(
+			"%s matches no domain (%d file(s), %d statements) — no minimum is enforced there",
+			dir, s.files, s.stmts))
+	}
+	return warnings
+}

--- a/internal/application/warnings_test.go
+++ b/internal/application/warnings_test.go
@@ -1,0 +1,101 @@
+package application
+
+import (
+	"strings"
+	"testing"
+
+	"go.klarlabs.de/coverctl/internal/domain"
+)
+
+// An overlapping directory already warns. A directory owned by NO domain was
+// silent — and that is the dangerous one: an overlapping package is measured
+// twice, an unmatched package is measured never, and a newly added package is
+// unmatched by default. The table stays green while nothing enforces it.
+func TestUnmatchedPackageWarnings(t *testing.T) {
+	root := "/repo"
+	domainDirs := map[string][]string{"core": {"/repo/internal/core"}}
+	files := map[string]domain.CoverageStat{
+		"/repo/internal/core/a.go":    {Covered: 8, Total: 10},
+		"/repo/internal/newpkg/b.go":  {Covered: 0, Total: 12},
+		"/repo/internal/newpkg/c.go":  {Covered: 1, Total: 3},
+		"/repo/internal/another/d.go": {Covered: 0, Total: 5},
+	}
+
+	warnings := unmatchedPackageWarnings(files, domainDirs, nil, root, "", nil)
+	joined := strings.Join(warnings, "\n")
+
+	if len(warnings) != 2 {
+		t.Fatalf("expected one warning per unmatched directory, got %d:\n%s", len(warnings), joined)
+	}
+	if !strings.Contains(joined, "internal/newpkg") || !strings.Contains(joined, "internal/another") {
+		t.Errorf("warnings missing an unmatched directory:\n%s", joined)
+	}
+	if strings.Contains(joined, "internal/core") {
+		t.Errorf("warned about a directory that IS matched:\n%s", joined)
+	}
+	// The counts are what tell a reader whether this is a stray file or a whole
+	// subsystem going unenforced.
+	if !strings.Contains(joined, "2 file(s), 15 statements") {
+		t.Errorf("warning should carry file and statement counts:\n%s", joined)
+	}
+}
+
+func TestUnmatchedPackageWarnings_NoneWhenAllMatched(t *testing.T) {
+	warnings := unmatchedPackageWarnings(
+		map[string]domain.CoverageStat{"/repo/internal/core/a.go": {Covered: 1, Total: 2}},
+		map[string][]string{"core": {"/repo/internal/core"}},
+		nil, "/repo", "", nil,
+	)
+	if len(warnings) != 0 {
+		t.Errorf("expected no warnings, got %v", warnings)
+	}
+}
+
+// Excluded paths and ignore annotations are deliberate omissions, not gaps, so
+// they must not be reported as unenforced.
+func TestUnmatchedPackageWarnings_RespectsExcludesAndAnnotations(t *testing.T) {
+	root := "/repo"
+	domainDirs := map[string][]string{"core": {"/repo/internal/core"}}
+	files := map[string]domain.CoverageStat{
+		"/repo/internal/generated/x.go": {Covered: 0, Total: 9},
+		"/repo/internal/ignored/y.go":   {Covered: 0, Total: 4},
+		"/repo/internal/assigned/z.go":  {Covered: 0, Total: 4},
+	}
+	annotations := map[string]Annotation{
+		"internal/ignored/y.go":  {Ignore: true},
+		"internal/assigned/z.go": {Domain: "core"},
+	}
+
+	warnings := unmatchedPackageWarnings(files, domainDirs, []string{"internal/generated/*"}, root, "", annotations)
+	if len(warnings) != 0 {
+		t.Errorf("excluded/annotated files should not be reported: %v", warnings)
+	}
+}
+
+// With no domains configured at all there is nothing to be unmatched against —
+// warning on every directory would be noise, not signal.
+func TestUnmatchedPackageWarnings_NoDomainsConfigured(t *testing.T) {
+	warnings := unmatchedPackageWarnings(
+		map[string]domain.CoverageStat{"/repo/a.go": {Covered: 0, Total: 1}},
+		nil, nil, "/repo", "", nil,
+	)
+	if len(warnings) != 0 {
+		t.Errorf("expected silence with no domains, got %v", warnings)
+	}
+}
+
+func TestUnmatchedPackageWarnings_CapsTheList(t *testing.T) {
+	root := "/repo"
+	files := map[string]domain.CoverageStat{}
+	for _, d := range []string{"a", "b", "c", "d", "e", "f", "g"} {
+		files["/repo/internal/"+d+"/x.go"] = domain.CoverageStat{Total: 1}
+	}
+	warnings := unmatchedPackageWarnings(files, map[string][]string{"core": {"/repo/internal/core"}}, nil, root, "", nil)
+
+	if len(warnings) != maxUnmatchedDirsReported+1 {
+		t.Fatalf("expected %d entries plus a summary line, got %d: %v", maxUnmatchedDirsReported, len(warnings), warnings)
+	}
+	if !strings.Contains(warnings[len(warnings)-1], "2 more") {
+		t.Errorf("last line should summarize the remainder, got %q", warnings[len(warnings)-1])
+	}
+}

--- a/internal/cli/version.go
+++ b/internal/cli/version.go
@@ -1,6 +1,9 @@
 package cli
 
-// Version information, set at build time via ldflags
+import "runtime/debug"
+
+// Version information, set at build time via ldflags for released binaries and
+// otherwise recovered from the embedded build info (see applyBuildInfo).
 var (
 	// Version is the semantic version (e.g., "1.2.3")
 	Version = "dev"
@@ -9,3 +12,45 @@ var (
 	// Date is the build date
 	Date = "unknown"
 )
+
+func init() { applyBuildInfo(debug.ReadBuildInfo) }
+
+// applyBuildInfo fills in whatever the linker did not.
+//
+// Only goreleaser passes -ldflags, so a binary from
+// `go install go.klarlabs.de/coverctl@latest` reported "dev" with no commit and
+// no date — including in CI, which installs exactly that way. A gate whose
+// version cannot be named is a gate whose behavior cannot be reproduced or
+// bisected: "the coverage check started failing" is unanswerable when every
+// install reports "dev".
+//
+// The module version and VCS stamp are already embedded by the toolchain, so
+// this needs no build plumbing. ldflags still win where present: they are
+// applied at link time, before init runs, and each field is filled only if it
+// still holds its zero-information default.
+func applyBuildInfo(read func() (*debug.BuildInfo, bool)) {
+	bi, ok := read()
+	if !ok || bi == nil {
+		return
+	}
+
+	// "(devel)" is what a local `go build` reports — no more informative than
+	// "dev", so leave the existing value rather than swap one placeholder for
+	// another.
+	if Version == "dev" && bi.Main.Version != "" && bi.Main.Version != "(devel)" {
+		Version = bi.Main.Version
+	}
+
+	for _, s := range bi.Settings {
+		switch s.Key {
+		case "vcs.revision":
+			if Commit == "unknown" && s.Value != "" {
+				Commit = s.Value
+			}
+		case "vcs.time":
+			if Date == "unknown" && s.Value != "" {
+				Date = s.Value
+			}
+		}
+	}
+}

--- a/internal/cli/version_test.go
+++ b/internal/cli/version_test.go
@@ -1,0 +1,81 @@
+package cli
+
+import (
+	"runtime/debug"
+	"testing"
+)
+
+func withVersionVars(t *testing.T, v, c, d string) {
+	t.Helper()
+	ov, oc, od := Version, Commit, Date
+	Version, Commit, Date = v, c, d
+	t.Cleanup(func() { Version, Commit, Date = ov, oc, od })
+}
+
+func buildInfo(mainVersion string, settings ...debug.BuildSetting) func() (*debug.BuildInfo, bool) {
+	return func() (*debug.BuildInfo, bool) {
+		return &debug.BuildInfo{
+			Main:     debug.Module{Version: mainVersion},
+			Settings: settings,
+		}, true
+	}
+}
+
+// `go install …@latest` sets no ldflags, so the released defaults survive and
+// the binary calls itself "dev" — CI installs exactly that way, which made the
+// gate's version unnameable.
+func TestApplyBuildInfo_FillsVersionFromModule(t *testing.T) {
+	withVersionVars(t, "dev", "unknown", "unknown")
+
+	applyBuildInfo(buildInfo("v1.4.2",
+		debug.BuildSetting{Key: "vcs.revision", Value: "abc123"},
+		debug.BuildSetting{Key: "vcs.time", Value: "2026-08-01T00:00:00Z"},
+	))
+
+	if Version != "v1.4.2" {
+		t.Errorf("Version = %q, want v1.4.2", Version)
+	}
+	if Commit != "abc123" {
+		t.Errorf("Commit = %q, want abc123", Commit)
+	}
+	if Date != "2026-08-01T00:00:00Z" {
+		t.Errorf("Date = %q, want the vcs.time stamp", Date)
+	}
+}
+
+// ldflags are applied at link time, before init, so a released binary must keep
+// the version goreleaser stamped rather than have it overwritten.
+func TestApplyBuildInfo_DoesNotOverrideLdflags(t *testing.T) {
+	withVersionVars(t, "1.2.3", "deadbeef", "2026-01-01")
+
+	applyBuildInfo(buildInfo("v9.9.9",
+		debug.BuildSetting{Key: "vcs.revision", Value: "zzz"},
+		debug.BuildSetting{Key: "vcs.time", Value: "2030-01-01"},
+	))
+
+	if Version != "1.2.3" || Commit != "deadbeef" || Date != "2026-01-01" {
+		t.Errorf("build info overwrote ldflags: %s / %s / %s", Version, Commit, Date)
+	}
+}
+
+// A local `go build` reports "(devel)", which says no more than "dev" — swapping
+// one placeholder for another would only look like progress.
+func TestApplyBuildInfo_IgnoresDevelPlaceholder(t *testing.T) {
+	withVersionVars(t, "dev", "unknown", "unknown")
+
+	applyBuildInfo(buildInfo("(devel)"))
+
+	if Version != "dev" {
+		t.Errorf("Version = %q, want dev left in place", Version)
+	}
+}
+
+func TestApplyBuildInfo_NoBuildInfo(t *testing.T) {
+	withVersionVars(t, "dev", "unknown", "unknown")
+
+	applyBuildInfo(func() (*debug.BuildInfo, bool) { return nil, false })
+
+	if Version != "dev" || Commit != "unknown" || Date != "unknown" {
+		t.Errorf("unexpected mutation without build info: %s / %s / %s", Version, Commit, Date)
+	}
+}

--- a/internal/pathutil/validate.go
+++ b/internal/pathutil/validate.go
@@ -52,8 +52,15 @@ func ValidatePath(path string) (string, error) {
 //   - Null bytes anywhere → ErrNullBytes
 //   - Path starts with `~` → ErrPathEscapesBase (no shell expansion happens;
 //     literal `~` rarely intended and a common attempt at home-dir pivot)
-//   - Absolute path → ErrPathEscapesBase (callers must use root-relative paths)
+//   - Absolute path outside root → ErrPathEscapesBase
 //   - Cleaned path resolves outside root (via `..` or symlink) → ErrPathEscapesBase
+//
+// An absolute path INSIDE root is accepted. Being absolute is not itself an
+// escape: containment is what enforces scope, and that check applies to both
+// forms identically. Rejecting absolutes outright refused legitimate in-root
+// paths — passing a project's own `/…/repo/.coverctl.yaml` failed while the
+// relative form succeeded — and contradicted the remediation text callers are
+// given, which states that absolute paths under the project root are accepted.
 func ValidateScopedPath(path, root string) (string, error) {
 	if path == "" {
 		return "", ErrEmptyPath
@@ -62,9 +69,6 @@ func ValidateScopedPath(path, root string) (string, error) {
 		return "", ErrNullBytes
 	}
 	if strings.HasPrefix(path, "~") {
-		return "", ErrPathEscapesBase
-	}
-	if filepath.IsAbs(path) {
 		return "", ErrPathEscapesBase
 	}
 
@@ -78,20 +82,45 @@ func ValidateScopedPath(path, root string) (string, error) {
 		absRoot = resolved
 	}
 
-	joined := filepath.Join(absRoot, path)
-	cleaned := filepath.Clean(joined)
-
-	// Symlink resolution: if the path exists, resolve and re-check containment.
-	// If it doesn't exist (creating a new file), the textual prefix check below
-	// is sufficient since Clean has already collapsed any `..` segments.
-	if resolved, rErr := filepath.EvalSymlinks(cleaned); rErr == nil {
-		cleaned = resolved
+	cleaned := filepath.Clean(path)
+	if !filepath.IsAbs(cleaned) {
+		cleaned = filepath.Clean(filepath.Join(absRoot, path))
 	}
+
+	// Symlink resolution: resolve the deepest existing ancestor, then re-attach
+	// the not-yet-existing remainder. Resolving only the full path would leave a
+	// path that does not exist yet (creating a new file) unresolved, so a root
+	// reached through a symlink — macOS /tmp → /private/tmp is the common one —
+	// would fail the prefix check below despite being genuinely inside root.
+	cleaned = resolveExistingPrefix(cleaned)
 
 	if !pathHasPrefix(cleaned, absRoot) {
 		return "", ErrPathEscapesBase
 	}
 	return cleaned, nil
+}
+
+// resolveExistingPrefix resolves symlinks in the longest existing prefix of p
+// and re-joins the remaining (not yet existing) segments. `..` segments have
+// already been collapsed by Clean before this is called, so re-joining cannot
+// reintroduce traversal.
+func resolveExistingPrefix(p string) string {
+	remainder := ""
+	current := p
+	for {
+		if resolved, err := filepath.EvalSymlinks(current); err == nil {
+			if remainder == "" {
+				return resolved
+			}
+			return filepath.Join(resolved, remainder)
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return p // reached the volume root without finding anything that exists
+		}
+		remainder = filepath.Join(filepath.Base(current), remainder)
+		current = parent
+	}
 }
 
 // pathHasPrefix reports whether path is equal to root or lies strictly within

--- a/internal/pathutil/validate_test.go
+++ b/internal/pathutil/validate_test.go
@@ -361,3 +361,65 @@ func TestValidatePath_CleanedPath(t *testing.T) {
 		})
 	}
 }
+
+// An absolute path that resolves inside root must be accepted. It was rejected
+// outright, which refused a project's own `/…/repo/.coverctl.yaml` while the
+// relative form worked — and contradicted the remediation text callers get,
+// which says absolute paths under the project root are accepted.
+func TestValidateScopedPath_AcceptsAbsoluteInsideRoot(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "coverctl.yaml"), []byte("x"), 0o600); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	abs := filepath.Join(root, "coverctl.yaml")
+	got, err := ValidateScopedPath(abs, root)
+	if err != nil {
+		t.Fatalf("ValidateScopedPath(%q, %q) = %v, want it accepted", abs, root, err)
+	}
+
+	rel, relErr := ValidateScopedPath("coverctl.yaml", root)
+	if relErr != nil {
+		t.Fatalf("relative form failed: %v", relErr)
+	}
+	if got != rel {
+		t.Errorf("absolute and relative forms disagree: %q vs %q", got, rel)
+	}
+}
+
+// The containment check, not the absolute/relative distinction, is what keeps
+// scope. An absolute path outside root must still be refused.
+func TestValidateScopedPath_StillRejectsAbsoluteOutsideRoot(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	target := filepath.Join(outside, "secret.txt")
+	if err := os.WriteFile(target, []byte("secret"), 0o600); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	for _, p := range []string{target, "/etc/passwd", filepath.Join(outside, "does-not-exist")} {
+		if _, err := ValidateScopedPath(p, root); err != ErrPathEscapesBase {
+			t.Errorf("ValidateScopedPath(%q) = %v, want ErrPathEscapesBase", p, err)
+		}
+	}
+}
+
+// A file that does not exist yet, under a root reached through a symlink, must
+// still be recognized as inside root — the case that motivated resolving the
+// deepest existing ancestor rather than the whole path.
+func TestValidateScopedPath_NonexistentUnderSymlinkedRoot(t *testing.T) {
+	real := t.TempDir()
+	link := filepath.Join(t.TempDir(), "link")
+	if err := os.Symlink(real, link); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	for _, p := range []string{"new-file.out", "sub/dir/new-file.out"} {
+		if _, err := ValidateScopedPath(p, link); err != nil {
+			t.Errorf("ValidateScopedPath(%q, symlinked root) = %v, want accepted", p, err)
+		}
+		if _, err := ValidateScopedPath(filepath.Join(link, p), link); err != nil {
+			t.Errorf("absolute %q under symlinked root = %v, want accepted", p, err)
+		}
+	}
+}


### PR DESCRIPTION
Three items from #126 — after [retracting the two that were wrong](https://github.com/klarlabs-studio/coverctl/issues/126#issuecomment-5150969428).

## 1. `ValidateScopedPath` rejected every absolute path

A project's own `/…/repo/.coverctl.yaml` failed while `coverctl.yaml` worked — and the remediation text callers are handed says the opposite:

> Use relative paths or **absolute paths under the project root**

Being absolute is not itself an escape. **Containment** is what enforces scope, and it applies to both forms identically. Absolute paths *outside* root are still refused — pinned by the existing `/etc/passwd` case and a new test covering a real out-of-root file and a non-existent one.

While there: symlink resolution now resolves the **deepest existing ancestor** instead of the whole path. Resolving only the full path left a not-yet-created file unresolved, so a root reached through a symlink (macOS `/tmp` → `/private/tmp`) failed the prefix check despite being genuinely inside root.

## 2. `version` reported `dev` for anything goreleaser didn't build

Including `go install go.klarlabs.de/coverctl@latest` — which is what CI runs. A gate whose version can't be named can't be reproduced or bisected.

```
before   coverctl version dev
after    coverctl version v1.19.1-0.20260726135041-7ed76a82912a+dirty
           commit: 7ed76a82912a469bdcec39c8d6247a04e5ae2084
           built:  2026-07-26T13:50:41Z
```

The module version and VCS stamp are already embedded by the toolchain, so this needs no build plumbing. **ldflags still win where present** — they're applied at link time, before `init`, and each field is filled only if it still holds its default. Tested in both directions, plus the `(devel)` placeholder case (left as `dev`, since swapping one placeholder for another only looks like progress).

## 3. A directory owned by *no* domain was silent

An overlapping directory warns loudly. The unmatched case is the dangerous one: an overlapping package is measured **twice**, an unmatched package is measured **never** — and a newly added package is unmatched by default, so the table stays green while nothing enforces it.

`unmatchedPackageWarnings` mirrors `AggregateByDomainWithExcludes` exactly, so a directory it reports is precisely one that contributed to no domain. Deliberate omissions (excludes, ignore annotations, `coverctl:domain=` assignments) stay silent.

**It found real gaps on the first run:**

```
- internal/tui matches no domain (3 file(s), 182 statements) — no minimum is enforced there
- stepsdk matches no domain (1 file(s), 22 statements) — no minimum is enforced there
```

(that's warden; coverctl itself has one too)

### Scope — stated plainly

In a normal `check`, the profile is produced with `-coverpkg` scoped to the configured domains, so an unmatched package **isn't in the profile and can't be reported**. The warning fires where the profile covers more than the domains do: `--from-profile`, merged profiles, an external CI artifact.

Making it fire in the default path means enumerating module packages rather than reading the profile. That's a larger change and a design call that's yours, so I stopped here.

### Wired into all four paths

I first wired only `check_handler` — and the warning never fired, because the CLI goes through `Service.CheckResult`. The change looked complete and was completely inert. All four `domainOverlapWarnings` call sites now get it.

## Also: why coverctl's numbers differ from `go test ./...`

Documented in the README (#126 item 1). That measurement basis cost me **two wrong conclusions in one session** — a package reading `0.0%` under `go test` and `80%` here — so it's written from the mistake rather than from the design.

No output change for this one: a note printed after the table would be **wrong** under `--from-profile`, where the supplied profile may be plain `go test` output and the numbers really are per-package. Plumbing that distinction into the writer is a design call for you rather than something to guess at.

## A note on placement

The new functions live in `internal/application/warnings.go` rather than growing `service.go`. Adding them inline pushed that file to 1622 lines and tripped your architecture test, which says:

> extract before adding more. Do not raise the ceiling without doing the extraction first.

So `domainOverlapWarnings` moved out alongside the new one. `service.go` is now **1523** lines, comfortably under the 1600 ceiling, and the warning concern is in one place.

## Verification

`go build ./...` · `go vet ./...` clean · `go test ./...` **30/30 packages** · `golangci-lint run ./...` 0 issues · architecture fitness tests pass · dogfooded against both coverctl and warden.

Each new test was checked to fail without its fix.

https://claude.ai/code/session_014MdmjtEoya1PpaYiFLtTkz