### PR TITLE
fix: see unmatched packages the profile cannot, and mark inherited minimums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to `coverctl` will be documented here. Relicta manages this file automatically.
 
+## [Unreleased]
+
+### Fixed
+- **The unmatched-package warning could not see the packages that matter most.**
+  It was derived from the coverage profile, but a package with no test files
+  contributes no profile lines under a plain `go test ./...` — so a package that
+  was *both* unmatched and untested, the exact case the warning exists for, was
+  invisible to it. Package enumeration (`go list ./...`) now runs alongside the
+  profile pass. (#126)
+- **The capability was lost at the wrapper.** The CLI wires a `MultiResolver`
+  around the Go resolver; the warning type-asserts for the enumeration
+  capability, and the assertion failed against the wrapper even though the
+  resolver underneath implemented it. The warning degraded silently — it
+  reported nothing and looked like it had nothing to report. `MultiResolver`
+  now forwards enumeration to the selected resolver. (#126)
+
+### Changed
+- Domain thresholds inherited from `policy.default.min` are now marked
+  `80.0% (default)` in the table. A config where every domain reads `min: null`
+  reads as a disabled gate; the threshold *is* enforced, and printing a bare
+  number did not say so. (#126)
+
 ## [1.18.0] - 2026-07-06
 
 Security & correctness hardening from a full deep review. The headline theme is

--- a/internal/application/check_handler.go
+++ b/internal/application/check_handler.go
@@ -166,7 +166,7 @@ func (h *CheckHandler) CheckResult(ctx context.Context, opts CheckOptions) (doma
 	result := domain.Evaluate(policy, domainCoverage)
 	result.Warnings = domainOverlapWarnings(domainDirs)
 	result.Warnings = append(result.Warnings,
-		unmatchedPackageWarnings(filteredCoverage, domainDirs, cfg.Exclude, moduleRoot, modulePath, annotations)...)
+		unmatchedPackageWarnings(filteredCoverage, domainDirs, cfg.Exclude, moduleRoot, modulePath, annotations, enumeratePackageFiles(ctx, h.DomainResolver))...)
 	if len(fromProfileWarnings) > 0 {
 		result.Warnings = append(result.Warnings, fromProfileWarnings...)
 	}

--- a/internal/application/report_handler.go
+++ b/internal/application/report_handler.go
@@ -101,7 +101,7 @@ func (h *ReportHandler) ReportResult(ctx context.Context, opts ReportOptions) (d
 	result := domain.Evaluate(policy, domainCoverage)
 	result.Warnings = domainOverlapWarnings(domainDirs)
 	result.Warnings = append(result.Warnings,
-		unmatchedPackageWarnings(filteredCoverage, domainDirs, cfg.Exclude, moduleRoot, modulePath, annotations)...)
+		unmatchedPackageWarnings(filteredCoverage, domainDirs, cfg.Exclude, moduleRoot, modulePath, annotations, enumeratePackageFiles(ctx, h.DomainResolver))...)
 
 	fileResults, filesPassed := evaluateFileRules(filteredCoverage, cfg.Files, cfg.Exclude, annotations)
 	result.Files = fileResults

--- a/internal/application/service.go
+++ b/internal/application/service.go
@@ -272,7 +272,7 @@ func (s *Service) CheckResult(ctx context.Context, opts CheckOptions) (domain.Re
 	result := domain.Evaluate(policy, domainCoverage)
 	result.Warnings = domainOverlapWarnings(domainDirs)
 	result.Warnings = append(result.Warnings,
-		unmatchedPackageWarnings(filteredCoverage, domainDirs, cfg.Exclude, moduleRoot, modulePath, annotations)...)
+		unmatchedPackageWarnings(filteredCoverage, domainDirs, cfg.Exclude, moduleRoot, modulePath, annotations, enumeratePackageFiles(ctx, s.DomainResolver))...)
 	if len(fromProfileWarnings) > 0 {
 		result.Warnings = append(result.Warnings, fromProfileWarnings...)
 	}
@@ -455,7 +455,7 @@ func (s *Service) ReportResult(ctx context.Context, opts ReportOptions) (domain.
 	result := domain.Evaluate(policy, domainCoverage)
 	result.Warnings = domainOverlapWarnings(domainDirs)
 	result.Warnings = append(result.Warnings,
-		unmatchedPackageWarnings(filteredCoverage, domainDirs, cfg.Exclude, moduleRoot, modulePath, annotations)...)
+		unmatchedPackageWarnings(filteredCoverage, domainDirs, cfg.Exclude, moduleRoot, modulePath, annotations, enumeratePackageFiles(ctx, s.DomainResolver))...)
 	fileResults, filesPassed := evaluateFileRules(filteredCoverage, cfg.Files, cfg.Exclude, annotations)
 	result.Files = fileResults
 	if !filesPassed {

--- a/internal/application/types.go
+++ b/internal/application/types.go
@@ -342,6 +342,23 @@ type DomainResolver interface {
 	ModulePath(ctx context.Context) (string, error)
 }
 
+// PackageEnumerator is an optional capability a DomainResolver may also
+// implement: listing every package in the project, not only those some domain
+// pattern already matched.
+//
+// It is deliberately separate from DomainResolver rather than another method on
+// it. Only the Go resolver can enumerate packages this way, and the unmatched
+// warning degrades honestly without it — a resolver that cannot enumerate still
+// reports every unmatched directory the coverage profile knows about, just not
+// the ones absent from the profile entirely.
+// It returns each package directory mapped to the base names of its non-test Go
+// files. Files rather than bare directories, because a package whose every file
+// is excluded is not a gap and must not warn — the same exclusion predicate the
+// aggregation uses has to be applied per file.
+type PackageEnumerator interface {
+	AllPackageFiles(ctx context.Context) (map[string][]string, error)
+}
+
 // CoverageRunner executes tests with coverage instrumentation for a specific language.
 // Implementations exist for Go, Python, Node.js, Rust, and Java.
 type CoverageRunner interface {

--- a/internal/application/warnings.go
+++ b/internal/application/warnings.go
@@ -1,6 +1,7 @@
 package application
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 	"sort"
@@ -8,6 +9,26 @@ import (
 
 	"go.klarlabs.de/coverctl/internal/domain"
 )
+
+// enumeratePackageFiles asks the resolver to list every package in the project,
+// if it is able to. A resolver that cannot — a non-Go project, or a test double
+// — yields nil, and the unmatched warning falls back to what the coverage
+// profile alone can show.
+//
+// A failure is swallowed on purpose. This feeds a warning, not a gate: a
+// project that cannot be enumerated has a louder problem than an unmatched
+// package, and failing the coverage check over it would report the wrong thing.
+func enumeratePackageFiles(ctx context.Context, r DomainResolver) map[string][]string {
+	enum, ok := r.(PackageEnumerator)
+	if !ok {
+		return nil
+	}
+	files, err := enum.AllPackageFiles(ctx)
+	if err != nil {
+		return nil
+	}
+	return files
+}
 
 // Warnings surface configuration problems that are not policy failures: the
 // check still passes, but something about the domain layout means the result
@@ -51,7 +72,15 @@ const maxUnmatchedDirsReported = 5
 // there. Anything the aggregation skips outright — excluded paths, ignore
 // annotations — is skipped here too, because those are deliberate omissions
 // rather than gaps.
-func unmatchedPackageWarnings(files map[string]domain.CoverageStat, domainDirs map[string][]string, exclude []string, moduleRoot, modulePath string, annotations map[string]Annotation) []string {
+//
+// allPackageFiles, when non-nil, maps every package directory in the project to
+// its non-test Go files (see PackageEnumerator). It exists because the coverage
+// profile is not a complete list of the project's packages: a package with no
+// test files produces no profile lines under a plain `go test ./...`, so a
+// package that is BOTH unmatched and untested — the worst case, and the one
+// this warning is for — is invisible to the profile. When it is nil the warning
+// degrades to what the profile can see rather than reporting nothing.
+func unmatchedPackageWarnings(files map[string]domain.CoverageStat, domainDirs map[string][]string, exclude []string, moduleRoot, modulePath string, annotations map[string]Annotation, allPackageFiles map[string][]string) []string {
 	if len(domainDirs) == 0 {
 		return nil // no domains configured at all: not this warning's business
 	}
@@ -59,6 +88,12 @@ func unmatchedPackageWarnings(files map[string]domain.CoverageStat, domainDirs m
 	type dirStat struct {
 		files int
 		stmts int
+		// inProfile records whether any covered file was seen for this
+		// directory. A directory known only from enumeration reports
+		// differently: "no coverage data" is a stronger statement than
+		// "unmatched", and conflating them would misreport statement counts
+		// as zero when they are simply unknown.
+		inProfile bool
 	}
 	unmatched := make(map[string]*dirStat)
 
@@ -87,7 +122,39 @@ func unmatchedPackageWarnings(files map[string]domain.CoverageStat, domainDirs m
 		}
 		unmatched[dir].files++
 		unmatched[dir].stmts += stat.Total
+		unmatched[dir].inProfile = true
 	}
+
+	// Second pass over every package the project actually has. This catches the
+	// packages the profile could not: no test files, so no profile lines, so
+	// invisible to the loop above no matter how badly they are unmatched.
+	for pkgDir, pkgFiles := range allPackageFiles {
+		if matchedByAnyDomain(pkgDir, domainDirs, moduleRoot) {
+			continue
+		}
+		relDir := moduleRelativePath(pkgDir, moduleRoot)
+		// A package whose every file is excluded or ignored is a deliberate
+		// omission, not a gap — the same rule the coverage pass applies.
+		live := 0
+		for _, base := range pkgFiles {
+			relPath := filepath.Join(relDir, base)
+			if excluded(relPath, exclude) {
+				continue
+			}
+			if ann, ok := annotations[filepath.ToSlash(relPath)]; ok && (ann.Ignore || ann.Domain != "") {
+				continue
+			}
+			live++
+		}
+		if live == 0 {
+			continue
+		}
+		dir := filepath.ToSlash(relDir)
+		if unmatched[dir] == nil {
+			unmatched[dir] = &dirStat{files: live}
+		}
+	}
+
 	if len(unmatched) == 0 {
 		return nil
 	}
@@ -105,9 +172,28 @@ func unmatchedPackageWarnings(files map[string]domain.CoverageStat, domainDirs m
 			break
 		}
 		s := unmatched[dir]
+		if !s.inProfile {
+			warnings = append(warnings, fmt.Sprintf(
+				"%s matches no domain (%d file(s), no coverage data) — no minimum is enforced there",
+				dir, s.files))
+			continue
+		}
 		warnings = append(warnings, fmt.Sprintf(
 			"%s matches no domain (%d file(s), %d statements) — no minimum is enforced there",
 			dir, s.files, s.stmts))
 	}
 	return warnings
+}
+
+// matchedByAnyDomain reports whether a package directory is claimed by some
+// domain. It reuses matchesAnyDir — which already treats "equal to" and "under"
+// a domain directory as a match — so an enumerated package is judged by exactly
+// the rule a covered file in it would be.
+func matchedByAnyDomain(pkgDir string, domainDirs map[string][]string, moduleRoot string) bool {
+	for _, dirs := range domainDirs {
+		if matchesAnyDir(pkgDir, dirs, moduleRoot) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/application/warnings_test.go
+++ b/internal/application/warnings_test.go
@@ -194,7 +194,7 @@ func TestUnmatchedPackageWarnings_EnumerationRespectsExcludesAndAnnotations(t *t
 }
 
 // A resolver that cannot enumerate (non-Go project, or a test double) must
-// degrade to the profile-only behaviour rather than panicking or reporting
+// degrade to the profile-only behavior rather than panicking or reporting
 // nothing at all.
 func TestEnumeratePackageFiles_NilWhenResolverCannotEnumerate(t *testing.T) {
 	if got := enumeratePackageFiles(t.Context(), nonEnumeratingResolver{}); got != nil {

--- a/internal/application/warnings_test.go
+++ b/internal/application/warnings_test.go
@@ -1,6 +1,7 @@
 package application
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -21,7 +22,7 @@ func TestUnmatchedPackageWarnings(t *testing.T) {
 		"/repo/internal/another/d.go": {Covered: 0, Total: 5},
 	}
 
-	warnings := unmatchedPackageWarnings(files, domainDirs, nil, root, "", nil)
+	warnings := unmatchedPackageWarnings(files, domainDirs, nil, root, "", nil, nil)
 	joined := strings.Join(warnings, "\n")
 
 	if len(warnings) != 2 {
@@ -44,7 +45,7 @@ func TestUnmatchedPackageWarnings_NoneWhenAllMatched(t *testing.T) {
 	warnings := unmatchedPackageWarnings(
 		map[string]domain.CoverageStat{"/repo/internal/core/a.go": {Covered: 1, Total: 2}},
 		map[string][]string{"core": {"/repo/internal/core"}},
-		nil, "/repo", "", nil,
+		nil, "/repo", "", nil, nil,
 	)
 	if len(warnings) != 0 {
 		t.Errorf("expected no warnings, got %v", warnings)
@@ -66,7 +67,7 @@ func TestUnmatchedPackageWarnings_RespectsExcludesAndAnnotations(t *testing.T) {
 		"internal/assigned/z.go": {Domain: "core"},
 	}
 
-	warnings := unmatchedPackageWarnings(files, domainDirs, []string{"internal/generated/*"}, root, "", annotations)
+	warnings := unmatchedPackageWarnings(files, domainDirs, []string{"internal/generated/*"}, root, "", annotations, nil)
 	if len(warnings) != 0 {
 		t.Errorf("excluded/annotated files should not be reported: %v", warnings)
 	}
@@ -77,7 +78,7 @@ func TestUnmatchedPackageWarnings_RespectsExcludesAndAnnotations(t *testing.T) {
 func TestUnmatchedPackageWarnings_NoDomainsConfigured(t *testing.T) {
 	warnings := unmatchedPackageWarnings(
 		map[string]domain.CoverageStat{"/repo/a.go": {Covered: 0, Total: 1}},
-		nil, nil, "/repo", "", nil,
+		nil, nil, "/repo", "", nil, nil,
 	)
 	if len(warnings) != 0 {
 		t.Errorf("expected silence with no domains, got %v", warnings)
@@ -90,7 +91,7 @@ func TestUnmatchedPackageWarnings_CapsTheList(t *testing.T) {
 	for _, d := range []string{"a", "b", "c", "d", "e", "f", "g"} {
 		files["/repo/internal/"+d+"/x.go"] = domain.CoverageStat{Total: 1}
 	}
-	warnings := unmatchedPackageWarnings(files, map[string][]string{"core": {"/repo/internal/core"}}, nil, root, "", nil)
+	warnings := unmatchedPackageWarnings(files, map[string][]string{"core": {"/repo/internal/core"}}, nil, root, "", nil, nil)
 
 	if len(warnings) != maxUnmatchedDirsReported+1 {
 		t.Fatalf("expected %d entries plus a summary line, got %d: %v", maxUnmatchedDirsReported, len(warnings), warnings)
@@ -99,3 +100,112 @@ func TestUnmatchedPackageWarnings_CapsTheList(t *testing.T) {
 		t.Errorf("last line should summarize the remainder, got %q", warnings[len(warnings)-1])
 	}
 }
+
+// The whole point of enumerating packages: a package with no test files
+// contributes NO lines to a plain `go test ./...` profile, so a package that is
+// both unmatched and untested — the worst case — is invisible to the
+// profile-only pass. Before this, the warning could not see it at all.
+func TestUnmatchedPackageWarnings_FindsPackagesAbsentFromTheProfile(t *testing.T) {
+	root := "/repo"
+	domainDirs := map[string][]string{"core": {"/repo/internal/core"}}
+	// Only the matched package produced coverage. internal/untested has no test
+	// files, so it appears nowhere in the profile.
+	files := map[string]domain.CoverageStat{
+		"/repo/internal/core/a.go": {Covered: 8, Total: 10},
+	}
+	allPackages := map[string][]string{
+		"/repo/internal/core":     {"a.go"},
+		"/repo/internal/untested": {"b.go", "c.go"},
+	}
+
+	profileOnly := unmatchedPackageWarnings(files, domainDirs, nil, root, "", nil, nil)
+	if len(profileOnly) != 0 {
+		t.Fatalf("precondition: the profile alone cannot see this package, got %v", profileOnly)
+	}
+
+	warnings := unmatchedPackageWarnings(files, domainDirs, nil, root, "", nil, allPackages)
+	joined := strings.Join(warnings, "\n")
+	if len(warnings) != 1 {
+		t.Fatalf("expected the untested unmatched package to be reported, got %d:\n%s", len(warnings), joined)
+	}
+	if !strings.Contains(joined, "internal/untested") {
+		t.Errorf("wrong package reported:\n%s", joined)
+	}
+	// "0 statements" would be a lie — the statements are unknown, not absent.
+	if strings.Contains(joined, "0 statements") {
+		t.Errorf("must not report unknown coverage as zero statements:\n%s", joined)
+	}
+	if !strings.Contains(joined, "no coverage data") {
+		t.Errorf("should say the package has no coverage data:\n%s", joined)
+	}
+	if strings.Contains(joined, "internal/core") {
+		t.Errorf("warned about a matched package:\n%s", joined)
+	}
+}
+
+// Enumeration must not double-report a directory the profile already covered,
+// nor downgrade its statement counts to "no coverage data".
+func TestUnmatchedPackageWarnings_EnumerationDoesNotDuplicateProfileFindings(t *testing.T) {
+	root := "/repo"
+	domainDirs := map[string][]string{"core": {"/repo/internal/core"}}
+	files := map[string]domain.CoverageStat{
+		"/repo/internal/newpkg/b.go": {Covered: 0, Total: 12},
+	}
+	allPackages := map[string][]string{
+		"/repo/internal/newpkg": {"b.go"},
+	}
+
+	warnings := unmatchedPackageWarnings(files, domainDirs, nil, root, "", nil, allPackages)
+	joined := strings.Join(warnings, "\n")
+	if len(warnings) != 1 {
+		t.Fatalf("expected exactly one warning for one directory, got %d:\n%s", len(warnings), joined)
+	}
+	if !strings.Contains(joined, "1 file(s), 12 statements") {
+		t.Errorf("profile statement counts should survive enumeration:\n%s", joined)
+	}
+}
+
+// A package whose every file is excluded is a deliberate omission. Enumeration
+// bypasses the profile, so it must re-apply the exclusion rules itself or it
+// will warn about things the user explicitly opted out of.
+func TestUnmatchedPackageWarnings_EnumerationRespectsExcludesAndAnnotations(t *testing.T) {
+	root := "/repo"
+	domainDirs := map[string][]string{"core": {"/repo/internal/core"}}
+	allPackages := map[string][]string{
+		"/repo/internal/generated": {"x.go"},
+		"/repo/internal/ignored":   {"y.go"},
+		"/repo/internal/assigned":  {"z.go"},
+		"/repo/internal/real":      {"w.go"},
+	}
+	annotations := map[string]Annotation{
+		"internal/ignored/y.go":  {Ignore: true},
+		"internal/assigned/z.go": {Domain: "core"},
+	}
+
+	warnings := unmatchedPackageWarnings(
+		nil, domainDirs, []string{"internal/generated/*"}, root, "", annotations, allPackages)
+	joined := strings.Join(warnings, "\n")
+	if len(warnings) != 1 {
+		t.Fatalf("only the genuinely unenforced package should warn, got %d:\n%s", len(warnings), joined)
+	}
+	if !strings.Contains(joined, "internal/real") {
+		t.Errorf("expected internal/real, got:\n%s", joined)
+	}
+}
+
+// A resolver that cannot enumerate (non-Go project, or a test double) must
+// degrade to the profile-only behaviour rather than panicking or reporting
+// nothing at all.
+func TestEnumeratePackageFiles_NilWhenResolverCannotEnumerate(t *testing.T) {
+	if got := enumeratePackageFiles(t.Context(), nonEnumeratingResolver{}); got != nil {
+		t.Errorf("expected nil for a resolver without the capability, got %v", got)
+	}
+}
+
+type nonEnumeratingResolver struct{}
+
+func (nonEnumeratingResolver) Resolve(context.Context, []domain.Domain) (map[string][]string, error) {
+	return nil, nil
+}
+func (nonEnumeratingResolver) ModuleRoot(context.Context) (string, error) { return "", nil }
+func (nonEnumeratingResolver) ModulePath(context.Context) (string, error) { return "", nil }

--- a/internal/domain/policy.go
+++ b/internal/domain/policy.go
@@ -69,13 +69,19 @@ const (
 )
 
 type DomainResult struct {
-	Domain   string   `json:"domain"`
-	Covered  int      `json:"covered"`
-	Total    int      `json:"total"`
-	Percent  float64  `json:"percent"`
-	Required float64  `json:"required"`
-	Status   Status   `json:"status"`
-	Delta    *float64 `json:"delta,omitempty"` // Change from previous run
+	Domain   string  `json:"domain"`
+	Covered  int     `json:"covered"`
+	Total    int     `json:"total"`
+	Percent  float64 `json:"percent"`
+	Required float64 `json:"required"`
+	// RequiredInherited records that Required came from the policy default
+	// rather than the domain's own `min`. A config where every domain reads
+	// `min: null` looks like a disabled gate; showing the threshold without
+	// showing where it came from does not dispel that. Reported so the table
+	// can mark the value as inherited.
+	RequiredInherited bool     `json:"required_inherited,omitempty"`
+	Status            Status   `json:"status"`
+	Delta             *float64 `json:"delta,omitempty"` // Change from previous run
 }
 
 // IsPassing returns true if this domain meets its coverage requirement.
@@ -309,8 +315,10 @@ func Evaluate(policy Policy, coverage map[string]CoverageStat) Result {
 	for _, d := range policy.Domains {
 		stat := coverage[d.Name]
 		required := policy.DefaultMin
+		inherited := true
 		if d.Min != nil {
 			required = *d.Min
+			inherited = false
 		}
 		// Compare the raw percentage against the threshold so that a value just
 		// under the bound (e.g. 79.95%) cannot round up to 80.0 and pass an 80%
@@ -326,12 +334,13 @@ func Evaluate(policy Policy, coverage map[string]CoverageStat) Result {
 			status = StatusWarn
 		}
 		results = append(results, DomainResult{
-			Domain:   d.Name,
-			Covered:  stat.Covered,
-			Total:    stat.Total,
-			Percent:  percent,
-			Required: required,
-			Status:   status,
+			Domain:            d.Name,
+			Covered:           stat.Covered,
+			Total:             stat.Total,
+			Percent:           percent,
+			Required:          required,
+			RequiredInherited: inherited,
+			Status:            status,
 		})
 	}
 

--- a/internal/infrastructure/gotool/resolver.go
+++ b/internal/infrastructure/gotool/resolver.go
@@ -17,8 +17,10 @@ type DomainResolver struct {
 }
 
 type goPackage struct {
-	Dir        string `json:"Dir"`
-	ImportPath string `json:"ImportPath"`
+	Dir        string   `json:"Dir"`
+	ImportPath string   `json:"ImportPath"`
+	GoFiles    []string `json:"GoFiles"`
+	CgoFiles   []string `json:"CgoFiles"`
 }
 
 func (r DomainResolver) Resolve(ctx context.Context, domains []domain.Domain) (map[string][]string, error) {
@@ -110,6 +112,43 @@ func matchPattern(importPath, pattern, modulePath string) bool {
 
 	// Exact match
 	return importPath == absPattern
+}
+
+// AllPackageFiles lists every package in the module with the base names of its
+// non-test Go files, whether or not any domain pattern matches the package and
+// whether or not it appears in a coverage profile.
+//
+// The unmatched-package warning cannot be derived from the coverage profile
+// alone. A package with no test files contributes no profile lines under a
+// plain `go test ./...`, so the very packages most likely to be both unmatched
+// AND untested are exactly the ones the profile cannot report. Enumerating the
+// module directly is the only way to see them.
+//
+// Test files are omitted: they carry no coverage obligation of their own, and a
+// package consisting only of them is not a hole in the policy.
+func (r DomainResolver) AllPackageFiles(ctx context.Context) (map[string][]string, error) {
+	moduleRoot, err := r.Module.ModuleRoot(ctx)
+	if err != nil {
+		return nil, err
+	}
+	pkgs, err := goList(ctx, moduleRoot, "./...")
+	if err != nil {
+		return nil, fmt.Errorf("go list ./...: %w", err)
+	}
+	out := make(map[string][]string, len(pkgs))
+	for _, pkg := range pkgs {
+		if pkg.Dir == "" {
+			continue
+		}
+		files := make([]string, 0, len(pkg.GoFiles)+len(pkg.CgoFiles))
+		files = append(files, pkg.GoFiles...)
+		files = append(files, pkg.CgoFiles...)
+		if len(files) == 0 {
+			continue
+		}
+		out[pkg.Dir] = append(out[pkg.Dir], files...)
+	}
+	return out, nil
 }
 
 func (r DomainResolver) ModuleRoot(ctx context.Context) (string, error) {

--- a/internal/infrastructure/report/writer.go
+++ b/internal/infrastructure/report/writer.go
@@ -89,6 +89,15 @@ func writeText(w io.Writer, result domain.Result) error {
 			statusText = fmt.Sprintf("%s (%+.1f%%)", statusText, d.Percent-d.Required)
 		}
 
+		// A domain that inherits its threshold is marked as such. Configs where
+		// every domain reads `min: null` look like a disabled gate; printing a
+		// bare "80.0%" does not say whether that number is enforced or a
+		// placeholder, and "(default)" answers it in the table itself.
+		requiredStr := fmt.Sprintf("%.1f%%", d.Required)
+		if d.RequiredInherited {
+			requiredStr += " (default)"
+		}
+
 		if hasDeltas {
 			deltaStr := "-"
 			if d.Delta != nil {
@@ -101,9 +110,9 @@ func writeText(w io.Writer, result domain.Result) error {
 					}
 				}
 			}
-			_, _ = fmt.Fprintf(tw, "%s\t%.1f%%\t%s\t%.1f%%\t%s\n", d.Domain, d.Percent, deltaStr, d.Required, statusText)
+			_, _ = fmt.Fprintf(tw, "%s\t%.1f%%\t%s\t%s\t%s\n", d.Domain, d.Percent, deltaStr, requiredStr, statusText)
 		} else {
-			_, _ = fmt.Fprintf(tw, "%s\t%.1f%%\t%.1f%%\t%s\n", d.Domain, d.Percent, d.Required, statusText)
+			_, _ = fmt.Fprintf(tw, "%s\t%.1f%%\t%s\t%s\n", d.Domain, d.Percent, requiredStr, statusText)
 		}
 	}
 	if err := tw.Flush(); err != nil {

--- a/internal/infrastructure/report/writer_test.go
+++ b/internal/infrastructure/report/writer_test.go
@@ -455,3 +455,40 @@ func TestWriteBriefEmpty(t *testing.T) {
 		t.Fatalf("expected 0/0 domains, got: %q", output)
 	}
 }
+
+// A config where every domain reads `min: null` looks like a disabled gate. The
+// threshold IS enforced — it is inherited from the policy default — but a bare
+// "80.0%" in the table does not say whether that number is real or a
+// placeholder. Marking the inherited ones answers it where the reader is
+// already looking.
+func TestWriteText_MarksInheritedThresholds(t *testing.T) {
+	result := domain.Result{
+		Passed: true,
+		Domains: []domain.DomainResult{
+			{Domain: "inherits", Percent: 91.0, Required: 80.0, RequiredInherited: true, Status: domain.StatusPass},
+			{Domain: "explicit", Percent: 96.0, Required: 95.0, Status: domain.StatusPass},
+		},
+	}
+
+	buf := new(bytes.Buffer)
+	if err := (Writer{}).Write(buf, result, application.OutputText); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	out := buf.String()
+
+	for _, line := range strings.Split(out, "\n") {
+		switch {
+		case strings.HasPrefix(line, "inherits"):
+			if !strings.Contains(line, "80.0% (default)") {
+				t.Errorf("inherited threshold should be marked, got: %q", line)
+			}
+		case strings.HasPrefix(line, "explicit"):
+			if strings.Contains(line, "(default)") {
+				t.Errorf("an explicit min must NOT be marked inherited, got: %q", line)
+			}
+			if !strings.Contains(line, "95.0%") {
+				t.Errorf("explicit threshold missing, got: %q", line)
+			}
+		}
+	}
+}

--- a/internal/infrastructure/resolver/multi.go
+++ b/internal/infrastructure/resolver/multi.go
@@ -44,6 +44,23 @@ func (r *MultiResolver) ModulePath(ctx context.Context) (string, error) {
 	return resolver.ModulePath(ctx)
 }
 
+// AllPackageFiles forwards the package-enumeration capability to whichever
+// resolver is selected, when that resolver has it.
+//
+// Without this the capability is lost at the wrapper: the CLI wires a
+// MultiResolver, the unmatched-package warning type-asserts for
+// application.PackageEnumerator, the assertion fails against the wrapper even
+// though the Go resolver underneath implements it, and the warning silently
+// degrades to profile-only. It reported nothing, and looked like it had nothing
+// to report.
+func (r *MultiResolver) AllPackageFiles(ctx context.Context) (map[string][]string, error) {
+	enum, ok := r.selectResolver().(application.PackageEnumerator)
+	if !ok {
+		return nil, nil
+	}
+	return enum.AllPackageFiles(ctx)
+}
+
 // selectResolver determines which resolver to use based on project language.
 func (r *MultiResolver) selectResolver() application.DomainResolver {
 	if r.registry == nil {

--- a/internal/infrastructure/resolver/multi_test.go
+++ b/internal/infrastructure/resolver/multi_test.go
@@ -161,3 +161,57 @@ func TestMultiResolverFallsBackToGo(t *testing.T) {
 		t.Errorf("expected Go resolver fallback, got %v", dirs)
 	}
 }
+
+// enumeratingResolver is a Go resolver that also implements the optional
+// package-enumeration capability.
+type enumeratingResolver struct {
+	fakeGoResolver
+	packages map[string][]string
+}
+
+func (e *enumeratingResolver) AllPackageFiles(context.Context) (map[string][]string, error) {
+	return e.packages, nil
+}
+
+// The capability must survive the wrapper. MultiResolver is what the CLI
+// actually wires, so a capability it fails to forward is a capability the
+// product does not have — the unmatched-package warning type-asserts for
+// PackageEnumerator, and against a non-forwarding wrapper the assertion fails
+// even though the Go resolver underneath implements it. That degraded silently:
+// the warning reported nothing and looked like it had nothing to report.
+func TestMultiResolver_ForwardsPackageEnumeration(t *testing.T) {
+	inner := &enumeratingResolver{
+		fakeGoResolver: fakeGoResolver{moduleRoot: "/repo", modulePath: "example.com/m"},
+		packages:       map[string][]string{"/repo/orphan": {"orphan.go"}},
+	}
+	// A nil registry makes selectResolver fall back to the Go resolver.
+	r := NewMultiResolver(inner, "/repo", nil)
+
+	// The assertion the warning code performs, made explicitly: a wrapper that
+	// stops satisfying this interface disables the warning without failing.
+	enum, ok := application.DomainResolver(r).(application.PackageEnumerator)
+	if !ok {
+		t.Fatal("MultiResolver must satisfy application.PackageEnumerator")
+	}
+
+	got, err := enum.AllPackageFiles(t.Context())
+	if err != nil {
+		t.Fatalf("AllPackageFiles: %v", err)
+	}
+	if len(got["/repo/orphan"]) != 1 || got["/repo/orphan"][0] != "orphan.go" {
+		t.Errorf("wrapper did not forward the inner resolver's packages: %v", got)
+	}
+}
+
+// A resolver without the capability (a non-Go project) must yield nothing
+// rather than panicking — the warning then degrades to profile-only.
+func TestMultiResolver_EnumerationAbsentWhenInnerCannot(t *testing.T) {
+	r := NewMultiResolver(&fakeGoResolver{moduleRoot: "/repo"}, "/repo", nil)
+	got, err := r.AllPackageFiles(t.Context())
+	if err != nil {
+		t.Fatalf("AllPackageFiles: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil when the inner resolver cannot enumerate, got %v", got)
+	}
+}


### PR DESCRIPTION
Closes the two remaining items from #126.

## The warning could not see the packages that matter most

The unmatched-package warning added in #127 was derived from the coverage profile. But a package with no test files contributes **no profile lines** under a plain `go test ./...` — so a package that was *both* unmatched and untested, the exact case the warning exists for, was invisible to it.

A second pass over `go list ./...` now runs alongside the profile pass. It re-applies the same exclusion and annotation rules, so deliberate omissions stay quiet, and skips packages holding only test files (they carry no coverage obligation of their own). A directory known only from enumeration reports `no coverage data` rather than `0 statements` — the statements are unknown, not absent.

## The capability was then lost at the wrapper

The CLI wires a `MultiResolver` around the Go resolver. The warning type-asserts for `application.PackageEnumerator`, and **the assertion failed against the wrapper** even though the resolver underneath implemented it. The warning degraded silently: it reported nothing, and looked like it had nothing to report.

The unit tests passed throughout. This was caught by building the binary and running it against a fixture module with a genuinely unmatched, untested package:

```
Warnings:
  - orphan matches no domain (1 file(s), no coverage data) — no minimum is enforced there
```

`MultiResolver` now forwards enumeration, and a test asserts the wrapper keeps satisfying the interface — a wrapper that stops doing so disables the warning without failing anything.

## `min: null` reads like a disabled gate

Item 4 of the issue. `Min` was already `*float64`, so *omitting* the key already inherits — the missing half was reporting. Inherited thresholds now render as `80.0% (default)`:

```
Domain          Coverage  Required         Status
application     84.5%     80.0% (default)  PASS
infrastructure  87.7%     80.0% (default)  PASS
```

## Verification

- Full suite green; `gofmt`/`go vet` clean.
- New tests mutation-checked: removing the enumeration pass fails
  `TestUnmatchedPackageWarnings_FindsPackagesAbsentFromTheProfile` and
  `..._EnumerationRespectsExcludesAndAnnotations`.
- Run against warden (the repo the issue came from): `(default)` markers appear on all
  9 domains, and no unmatched warnings fire — correctly, since its only unmatched
  packages are test-only (`e2e`, `scripts`) or excluded (`main.go`).

https://claude.ai/code/session_014MdmjtEoya1PpaYiFLtTkz