### PR TITLE
docs: DocsNext wayfinding + CLI other.mdx Diataxis polish

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -7,7 +7,7 @@ Status as of 2026-08-15 health-improvements pass. Items below marked
 ## Still open (prioritized)
 
 1. **5-user polyglot usability test** — protocol ready (`docs/research/usability-test-protocol.md`); no findings report yet (needs human participants).
-2. **Site content infra** — blog/RSS; remaining Diataxis polish on CLI `other.mdx`; universal Next component across all pages.
+2. **Site content infra** — blog/RSS still open. **SHIPPED:** Diataxis polish on CLI `other.mdx`; universal `DocsNext` component on CLI, configuration, installation, community, and MCP pages.
 3. **AI/Agent success metrics baseline** — telemetry flag exists; retained-value analysis of which 3 MCP tools drive usage is not yet instrumented end-to-end.
 4. **Activation funnel / GTM metrics** — specs exist; no live funnel dashboards.
 5. **Real polyglot toolchain smoke** — runners unit workflow + mocked buildArgs exist; optional CI with pytest-cov/nyc/cargo-llvm-cov still open.

--- a/docs/src/components/DocsNext.astro
+++ b/docs/src/components/DocsNext.astro
@@ -1,0 +1,52 @@
+---
+/**
+ * DocsNext — end-of-page wayfinding for Starlight MDX pages.
+ *
+ * Tutorial pages: pass one primary link (forward arrow feel).
+ * Reference / how-to: pass 2–3 links.
+ *
+ * Usage in MDX:
+ *   import DocsNext from '../../../components/DocsNext.astro';
+ *   <DocsNext links={[
+ *     { title: 'Configure domains', href: '/coverctl/configuration/domains/', description: 'Path groups and mins.' },
+ *   ]} />
+ */
+import { LinkCard, CardGrid } from '@astrojs/starlight/components';
+
+interface Link {
+  title: string;
+  href: string;
+  description?: string;
+}
+
+interface Props {
+  heading?: string;
+  links: Link[];
+}
+
+const { heading = 'Next', links } = Astro.props;
+---
+
+<section class="docs-next" aria-label={heading}>
+  <h2 id="next">{heading}</h2>
+  {links.length === 1 ? (
+    <LinkCard title={links[0].title} href={links[0].href} description={links[0].description} />
+  ) : (
+    <CardGrid>
+      {links.map((link) => (
+        <LinkCard title={link.title} href={link.href} description={link.description} />
+      ))}
+    </CardGrid>
+  )}
+</section>
+
+<style>
+  .docs-next {
+    margin-top: 2.5rem;
+    padding-top: 1.25rem;
+    border-top: 1px solid var(--sl-color-hairline);
+  }
+  .docs-next h2 {
+    margin-top: 0;
+  }
+</style>

--- a/docs/src/content/docs/cli/check.mdx
+++ b/docs/src/content/docs/cli/check.mdx
@@ -3,6 +3,8 @@ title: coverctl check
 description: Run tests with coverage and enforce per-domain policy. The wedge command of agent-loop coverage governance — agents call it inline before commit.
 ---
 
+import DocsNext from '../../../components/DocsNext.astro';
+
 The `check` command runs the project's **native** coverage runner, evaluates coverage per domain, and enforces policy thresholds from `.coverctl.yaml`. It is governance over `go test` / `pytest` / `npm test` / … — not a replacement for `go tool cover`.
 
 ## Usage
@@ -171,8 +173,10 @@ If `coverctl check` disagrees with previously recorded history, make sure the hi
 | `2` | Invalid configuration or arguments |
 | `3` | Test execution failed |
 
-## See Also
-
-- [run](/coverctl/cli/run/) - Run coverage without policy enforcement
-- [report](/coverctl/cli/report/) - Analyze existing coverage profile
-- [Configuration](/coverctl/configuration/) - Configure coverage policies
+<DocsNext
+  links={[
+    { title: 'suggest', href: '/coverctl/cli/other/#suggest', description: 'Propose thresholds after a check.' },
+    { title: 'run', href: '/coverctl/cli/run/', description: 'Produce a profile without enforcing policy.' },
+    { title: 'MCP check tool', href: '/coverctl/mcp/', description: 'Same gate, agent-callable.' },
+  ]}
+/>

--- a/docs/src/content/docs/cli/index.mdx
+++ b/docs/src/content/docs/cli/index.mdx
@@ -3,6 +3,8 @@ title: CLI overview
 description: coverctl CLI reference. The CLI is the substrate behind the MCP coverage server; humans use the same agent-loop coverage governance that AI agents do.
 ---
 
+import DocsNext from '../../../components/DocsNext.astro';
+
 The CLI is the substrate behind the MCP coverage server. Every tool the agent calls — `check`, `suggest`, `debt` — is also a CLI command. Humans use the same surface AI agents do; the policy file (`.coverctl.yaml`) is shared.
 
 The MCP server (`coverctl mcp serve`) is the canonical way to use coverctl inside an AI coding agent. The CLI is what you use from a terminal — and what powers everything underneath the agent.
@@ -103,3 +105,11 @@ coverctl report -o html > coverage.html
 # Watch mode during development
 coverctl watch -d core
 ```
+
+<DocsNext
+  links={[
+    { title: 'check', href: '/coverctl/cli/check/', description: 'Run tests and enforce domain policy.' },
+    { title: 'Other commands', href: '/coverctl/cli/other/', description: 'record, suggest, debt, compare, pr-comment, …' },
+    { title: 'Quick start (terminal)', href: '/coverctl/quick-start/', description: 'init → check golden path.' },
+  ]}
+/>

--- a/docs/src/content/docs/cli/init.mdx
+++ b/docs/src/content/docs/cli/init.mdx
@@ -3,6 +3,8 @@ title: coverctl init
 description: Auto-detect language and domains, write .coverctl.yaml. One-time setup for agent-loop coverage governance across 15 supported languages.
 ---
 
+import DocsNext from '../../../components/DocsNext.astro';
+
 The `init` command launches an interactive wizard to configure coverctl for your project. It auto-detects domains and lets you customize coverage thresholds.
 
 ## Usage
@@ -117,9 +119,11 @@ More language examples: [Quick start](/coverctl/quick-start/#after-init-example-
 | `1` | Detection / write failure |
 | `2` | Usage / flag error (e.g. config exists without `--force`) |
 
-## Related
-
-- [detect](/coverctl/cli/other/) — non-interactive domain detection (`coverctl detect --dry-run`)
-- [Configuration](/coverctl/configuration/) — `.coverctl.yaml` reference
-- [Domains](/coverctl/configuration/domains/) — match patterns and mins
-- [Quick start (terminal)](/coverctl/quick-start/) — golden path after init
+<DocsNext
+  heading="Related"
+  links={[
+    { title: 'detect', href: '/coverctl/cli/other/#detect', description: 'Non-interactive domain detection' },
+    { title: 'Configuration', href: '/coverctl/configuration/', description: '.coverctl.yaml reference' },
+    { title: 'Quick start', href: '/coverctl/quick-start/', description: 'Golden path after init' },
+  ]}
+/>

--- a/docs/src/content/docs/cli/other.mdx
+++ b/docs/src/content/docs/cli/other.mdx
@@ -1,432 +1,223 @@
 ---
 title: Other commands
-description: badge, trend, record, suggest, debt, compare, pr-comment, ignore, mcp, doctor, survey. The remaining surface of the agent-loop coverage governance CLI.
+description: Compact reference for badge, trend, record, suggest, debt, compare, pr-comment, ignore, detect, mcp, and related CLI commands.
 ---
 
-This page covers additional coverctl commands for badges, trends, and coverage analysis.
+import DocsNext from '../../../components/DocsNext.astro';
+
+Analysis and ops commands that are not the golden path (`init` → `check` → `suggest` → `record`). Each section is synopsis + flags + one example — scan, don't scroll a tutorial.
+
+## Command index
+
+| Command | One-liner |
+|---------|-----------|
+| [`pr-comment`](#pr-comment) | Post coverage as a PR/MR comment |
+| [`compare`](#compare) | Diff two coverage profiles |
+| [`badge`](#badge) | Write an SVG coverage badge |
+| [`trend`](#trend) | Show history trend |
+| [`record`](#record) | Append a history snapshot |
+| [`suggest`](#suggest) | Propose domain thresholds |
+| [`debt`](#debt) | Rank coverage gaps |
+| [`ignore`](#ignore) | List exclude patterns |
+| [`detect`](#detect) | Autodetect domains / write config |
+| [`mcp`](#mcp) | MCP server / doctor |
+| [`version`](#version) / [`help`](#help) | Meta |
+
+---
 
 ## pr-comment
-
-Post coverage reports as comments on GitHub, GitLab, or Bitbucket pull requests/merge requests.
 
 ```bash
 coverctl pr-comment [flags]
 ```
 
-### Flags
+Posts a coverage report on GitHub, GitLab, or Bitbucket. Prefer CI after `coverctl check`.
 
 | Flag | Description | Default |
 |------|-------------|---------|
-| `-c, --config` | Config file path | `.coverctl.yaml` |
-| `-p, --profile` | Coverage profile path | `.cover/coverage.out` |
-| `--base-profile` | Base coverage profile for comparison | |
-| `--provider` | Git provider: `github`, `gitlab`, `bitbucket`, `auto` | `auto` |
+| `-c, --config` | Config path | `.coverctl.yaml` |
+| `-p, --profile` | Coverage profile | `.cover/coverage.out` |
+| `--base-profile` | Base profile for deltas | |
+| `--provider` | `github` / `gitlab` / `bitbucket` / `auto` | `auto` |
 | `--pr` | PR/MR number | auto-detected |
-| `--owner` | Repository owner/namespace | auto-detected |
-| `--repo` | Repository name | auto-detected |
-| `--update` | Update existing comment instead of creating new | `true` |
-| `--dry-run` | Generate comment without posting | `false` |
-
-### Provider Auto-Detection
-
-The provider is automatically detected from environment variables:
-
-| Provider | Environment Variables |
-|----------|----------------------|
-| GitHub | `GITHUB_TOKEN`, `GITHUB_REPOSITORY` |
-| GitLab | `GITLAB_TOKEN`, `CI_JOB_TOKEN`, `CI_MERGE_REQUEST_IID` |
-| Bitbucket | `BITBUCKET_TOKEN`, `BITBUCKET_WORKSPACE`, `BITBUCKET_REPO_SLUG` |
-
-### Examples
+| `--owner` / `--repo` | Repository identity | auto-detected |
+| `--update` | Update existing coverctl comment | `true` |
+| `--dry-run` | Print body without posting | `false` |
 
 ```bash
-# GitHub Actions (auto-detects everything)
-coverctl pr-comment --pr ${{ github.event.pull_request.number }}
-
-# GitLab CI (MR number auto-detected from CI_MERGE_REQUEST_IID)
-coverctl pr-comment
-
-# Bitbucket Pipelines (PR number auto-detected from BITBUCKET_PR_ID)
-coverctl pr-comment
-
-# With coverage comparison to base branch
-coverctl pr-comment --pr 123 --base-profile main-coverage.out
-
-# Explicit provider
-coverctl pr-comment --provider gitlab --pr 42
-
-# Preview comment without posting
 coverctl pr-comment --pr 123 --dry-run
 ```
 
-### Comment Format
-
-The generated comment includes:
-
-- Overall coverage percentage and change
-- Domain-level coverage breakdown with status indicators
-- List of changed files with coverage deltas (when base profile provided)
-- Pass/fail status based on configured thresholds
+Provider tokens: `GITHUB_TOKEN`, `GITLAB_TOKEN` / `CI_JOB_TOKEN`, or `BITBUCKET_TOKEN` (+ workspace/repo vars).
 
 ---
 
 ## compare
 
-Compare coverage between two profiles to show improvements and regressions.
-
 ```bash
-coverctl compare [flags]
+coverctl compare --base <profile> [--head <profile>]
 ```
-
-### Flags
 
 | Flag | Description | Default |
 |------|-------------|---------|
-| `-c, --config` | Config file path | `.coverctl.yaml` |
-| `--base` | Base coverage profile (required) | |
-| `--head` | Head coverage profile | `.cover/coverage.out` |
-| `-o, --output` | Output format: `text`, `json` | `text` |
-
-### Examples
+| `--base` | Base profile (required) | |
+| `--head` | Head profile | `.cover/coverage.out` |
+| `-o, --output` | `text` / `json` | `text` |
 
 ```bash
-# Compare main branch to current
-coverctl compare --base main-coverage.out --head coverage.out
-
-# Compare two saved profiles
-coverctl compare --base v1.0.out --head v2.0.out
-
-# JSON output for CI parsing
-coverctl compare --base main.out -o json
-```
-
-### Output
-
-```
-Coverage Comparison
-───────────────────
-Base:  78.5%
-Head:  82.1%
-Delta: +3.6%
-
-Improved Files (5):
-  internal/core/validator.go   65.2% → 85.4%  (+20.2%)
-  internal/api/handler.go      72.1% → 78.3%  (+6.2%)
-  ...
-
-Regressed Files (1):
-  internal/cli/format.go       90.0% → 87.5%  (-2.5%)
+coverctl compare --base main.out --head .cover/coverage.out -o json
 ```
 
 ---
 
 ## badge
 
-Generate an SVG coverage badge for your README.
-
 ```bash
 coverctl badge [flags]
 ```
 
-### Flags
-
 | Flag | Description | Default |
 |------|-------------|---------|
-| `-c, --config` | Config file path | `.coverctl.yaml` |
-| `-p, --profile` | Coverage profile path | `.cover/coverage.out` |
-| `-o, --output` | Output file path | `coverage.svg` |
-| `--label` | Badge label text | `coverage` |
-| `--style` | Badge style: `flat`, `flat-square` | `flat` |
-
-### Examples
+| `-p, --profile` | Coverage profile | `.cover/coverage.out` |
+| `-o, --output` | SVG path | `coverage.svg` |
+| `--label` | Badge label | `coverage` |
+| `--style` | `flat` / `flat-square` | `flat` |
 
 ```bash
-# Generate default badge
-coverctl badge
-
-# Custom style and label
-coverctl badge --style flat-square --label "test coverage"
-
-# Custom output path
-coverctl badge -o docs/badge.svg
+coverctl badge -o docs/badge.svg --style flat-square
 ```
 
 ---
 
 ## trend
 
-Show coverage trends over time using recorded history.
-
 ```bash
 coverctl trend [flags]
 ```
 
-### Flags
-
 | Flag | Description | Default |
 |------|-------------|---------|
-| `-c, --config` | Config file path | `.coverctl.yaml` |
-| `-p, --profile` | Coverage profile path | `.cover/coverage.out` |
-| `--history` | History file path | `.cover/history.json` |
-| `-o, --output` | Output format: `text`, `json` | `text` |
-
-### Example
+| `--history` | History file | `.cover/history.json` |
+| `-o, --output` | `text` / `json` | `text` |
 
 ```bash
-# Show coverage trend
-coverctl trend
-
-# JSON output
 coverctl trend -o json
-```
-
-### Output
-
-```
-Coverage Trend (last 10 entries)
-────────────────────────────────
-Date         Commit    Coverage  Change
-2024-12-23   abc1234     82.1%   +0.5%
-2024-12-22   def5678     81.6%   +1.2%
-2024-12-21   ghi9012     80.4%   -0.3%
-...
 ```
 
 ---
 
 ## record
 
-Record current coverage to history for trend analysis.
-
 ```bash
 coverctl record [flags]
 ```
 
-Note: Prefer profiles produced by `coverctl run` or `coverctl check` so the history reflects the same `-coverpkg` instrumentation that policy checks use.
-When using `--run`, pass test selection via `--test-run` (or `--test-arg=-run=...`) since `--run` is reserved to trigger coverage execution.
-
-### Flags
+Prefer profiles from `coverctl check` / `coverctl run` so history matches policy instrumentation.
 
 | Flag | Description | Default |
 |------|-------------|---------|
-| `-c, --config` | Config file path | `.coverctl.yaml` |
-| `-p, --profile` | Coverage profile path | `.cover/coverage.out` |
-| `--history` | History file path | `.cover/history.json` |
-| `--commit` | Git commit SHA | auto-detected |
-| `--branch` | Git branch name | auto-detected |
-| `--run` | Run coverage before recording history | `false` |
+| `-p, --profile` | Coverage profile | `.cover/coverage.out` |
+| `--history` | History file | `.cover/history.json` |
+| `--commit` / `--branch` | Git metadata | auto-detected |
+| `--run` | Run coverage before recording | `false` |
 | `-l, --language` | Override language detection | auto |
-| `-d, --domain` | Filter to specific domain (repeatable) | all domains |
-| `--tags` | Build tags (e.g., `integration,e2e`) | |
-| `--race` | Enable race detector | `false` |
-| `--short` | Skip long-running tests | `false` |
-| `-v` | Verbose test output | `false` |
-| `--test-run` | Run only tests matching pattern | |
-| `--timeout` | Test timeout (e.g., `10m`, `1h`) | |
-| `--test-arg` | Additional go test argument (repeatable) | |
-
-### Examples
 
 ```bash
-# Record with auto-detected git info
-coverctl record
-
-# Explicit commit and branch
-coverctl record --commit abc1234 --branch main
-
-# Run coverage before recording history
-coverctl record --run --tags integration
-```
-
-### CI Integration
-
-```yaml
-# .github/workflows/coverage.yml
-- name: Record coverage
-  run: |
-    coverctl check
-    coverctl record --commit ${{ github.sha }} --branch ${{ github.ref_name }}
+coverctl record --commit "$GITHUB_SHA" --branch "$GITHUB_REF_NAME"
 ```
 
 ---
 
 ## suggest
 
-Suggest optimal coverage thresholds based on current coverage.
+```bash
+coverctl suggest [--strategy current|aggressive|conservative]
+```
+
+| Strategy | Behavior |
+|----------|----------|
+| `current` | Thresholds slightly below observed coverage |
+| `aggressive` | Push targets up |
+| `conservative` | Smaller incremental mins |
 
 ```bash
-coverctl suggest [flags]
-```
-
-### Flags
-
-| Flag | Description | Default |
-|------|-------------|---------|
-| `-c, --config` | Config file path | `.coverctl.yaml` |
-| `-p, --profile` | Coverage profile path | `.cover/coverage.out` |
-| `--strategy` | Strategy: `current`, `aggressive`, `conservative` | `current` |
-
-### Strategies
-
-| Strategy | Description |
-|----------|-------------|
-| `current` | Set thresholds slightly below current coverage |
-| `aggressive` | Push for higher thresholds |
-| `conservative` | Lower thresholds for gradual improvement |
-
-### Example
-
-```bash
-# Get suggestions
-coverctl suggest
-
-# Aggressive strategy
-coverctl suggest --strategy aggressive
-```
-
-### Output
-
-```
-Suggested Thresholds
-────────────────────
-Domain   Current  Suggested  Reason
-core       87.3%       85%   Slightly below current (buffer for variance)
-api        81.2%       80%   Slightly below current
-cli        76.4%       75%   Slightly below current
+coverctl suggest --strategy current
 ```
 
 ---
 
 ## debt
 
-Show coverage debt report identifying files that need more tests.
-
 ```bash
 coverctl debt [flags]
 ```
 
-### Flags
-
-| Flag | Description | Default |
-|------|-------------|---------|
-| `-c, --config` | Config file path | `.coverctl.yaml` |
-| `-p, --profile` | Coverage profile path | `.cover/coverage.out` |
-| `-o, --output` | Output format: `text`, `json` | `text` |
-
-### Example
+Ranks files/domains by shortfall vs policy. Use after a failing `check` to decide where to write tests.
 
 ```bash
-coverctl debt
-```
-
-### Output
-
-```
-Coverage Debt Report
-────────────────────
-File                           Current  Required  Shortfall
-internal/core/validator.go       65.2%      85%     -19.8%
-internal/api/handler.go          72.1%      80%      -7.9%
-────────────────────
-Total Debt: 27.7%
-Health Score: 73/100
+coverctl debt -o json
 ```
 
 ---
 
 ## ignore
 
-Show configured exclude patterns and ignored files.
-
-```bash
-coverctl ignore [flags]
-```
-
-### Flags
-
-| Flag | Description | Default |
-|------|-------------|---------|
-| `-c, --config` | Config file path | `.coverctl.yaml` |
-
-### Example
-
 ```bash
 coverctl ignore
 ```
 
-### Output
-
-```
-Configured Excludes
-───────────────────
-- **/generated/**
-- **/mocks/**
-- internal/testdata/*
-
-Ignored Files (matching excludes)
-─────────────────────────────────
-- internal/generated/proto/api.pb.go
-- internal/mocks/service_mock.go
-```
+Lists `exclude` patterns from `.coverctl.yaml` and matching files.
 
 ---
 
 ## detect
 
-Auto-detect domains and write configuration.
-
 ```bash
-coverctl detect [flags]
+coverctl detect [--dry-run] [--force]
 ```
 
-### Flags
-
-| Flag | Description | Default |
-|------|-------------|---------|
-| `-c, --config` | Config file path | `.coverctl.yaml` |
-| `--dry-run` | Preview config without writing | `false` |
-| `-f, --force` | Overwrite existing config | `false` |
-
-### Examples
+Non-interactive domain detection (sibling of `coverctl init --no-interactive`).
 
 ```bash
-# Preview detected domains
 coverctl detect --dry-run
-
-# Write config
-coverctl detect
-
-# Overwrite existing
-coverctl detect --force
 ```
+
+---
+
+## mcp
+
+```bash
+coverctl mcp serve [--mode=agent|ci|auto]
+coverctl mcp doctor
+```
+
+Agent mode advertises `check` / `suggest` / `debt`. Use `--mode=ci` for the full tool surface. `doctor` validates MCP wiring end-to-end. Full contract: [MCP server](/coverctl/mcp/).
 
 ---
 
 ## version
 
-Show version information.
-
 ```bash
 coverctl version
 ```
 
-### Output
+## help
 
-```
-coverctl v1.4.0 (abc1234) built 2024-12-23
+```bash
+coverctl help [command]
+coverctl check --help
 ```
 
 ---
 
-## help
+## Exit codes
 
-Show help for any command.
+Same family as the rest of the CLI: `0` success, `1` policy/soft failure, `2` usage/config, `3` runner failure (where applicable).
 
-```bash
-coverctl help [command]
-
-# Examples
-coverctl help
-coverctl help check
-coverctl check --help
-```
+<DocsNext
+  links={[
+    { title: 'check', href: '/coverctl/cli/check/', description: 'Enforce per-domain policy — the wedge command.' },
+    { title: 'CLI overview', href: '/coverctl/cli/', description: 'Global flags and command map.' },
+    { title: 'MCP server', href: '/coverctl/mcp/', description: 'Agent-callable tools and rejection schema.' },
+  ]}
+/>

--- a/docs/src/content/docs/cli/report.mdx
+++ b/docs/src/content/docs/cli/report.mdx
@@ -3,6 +3,8 @@ title: coverctl report
 description: Analyze an existing coverage profile without re-running tests. Same agent-loop coverage governance schema; reads profiles from any of 15 supported languages.
 ---
 
+import DocsNext from '../../../components/DocsNext.astro';
+
 The `report` command analyzes a pre-generated coverage profile and evaluates policies. Use this when you have coverage data from a previous run or CI artifact.
 
 ## Usage
@@ -176,7 +178,9 @@ coverctl report \
 | `2` | Invalid configuration or arguments |
 | `3` | Profile parsing failed |
 
-## See Also
-
-- [check](/coverctl/cli/check/) - Run tests and check coverage
-- [Configuration](/coverctl/configuration/) - Policy configuration
+<DocsNext
+  links={[
+    { title: 'check', href: '/coverctl/cli/check/', description: 'Run tests then enforce policy.' },
+    { title: 'Policy basics', href: '/coverctl/configuration/', description: 'What .coverctl.yaml evaluates.' },
+  ]}
+/>

--- a/docs/src/content/docs/cli/run.mdx
+++ b/docs/src/content/docs/cli/run.mdx
@@ -3,6 +3,8 @@ title: coverctl run
 description: Produce coverage artifacts without policy evaluation. Agent-loop coverage governance separates running coverage from enforcing policy; this is the run half.
 ---
 
+import DocsNext from '../../../components/DocsNext.astro';
+
 The `run` command runs tests with coverage instrumentation and generates a coverage profile, but does not evaluate policies. Use this when you only need the coverage data.
 
 ## Usage
@@ -109,8 +111,10 @@ coverctl report -p artifacts/coverage.out
 | `2` | Invalid configuration or arguments |
 | `3` | Test execution failed |
 
-## See Also
-
-- [check](/coverctl/cli/check/) - Run coverage with policy enforcement
-- [report](/coverctl/cli/report/) - Analyze existing coverage profile
-- [watch](/coverctl/cli/watch/) - Continuous coverage during development
+<DocsNext
+  links={[
+    { title: 'check', href: '/coverctl/cli/check/', description: 'Same run, plus policy enforcement.' },
+    { title: 'report', href: '/coverctl/cli/report/', description: 'Analyze an existing profile.' },
+    { title: 'watch', href: '/coverctl/cli/watch/', description: 'Re-run on file changes.' },
+  ]}
+/>

--- a/docs/src/content/docs/cli/watch.mdx
+++ b/docs/src/content/docs/cli/watch.mdx
@@ -3,6 +3,8 @@ title: coverctl watch
 description: Re-run coverage on file change during development. Continuous agent-loop coverage feedback for humans editing alongside AI agents.
 ---
 
+import DocsNext from '../../../components/DocsNext.astro';
+
 The `watch` command monitors your project for file changes and automatically re-runs coverage checks. Ideal for development workflows where you want continuous feedback.
 
 ## Usage
@@ -115,8 +117,11 @@ Running coverage check...
 
 Press `Ctrl+C` to stop watching.
 
-## Related
-
-- [check](/coverctl/cli/check/) — single coverage check
-- [run](/coverctl/cli/run/) — generate coverage profile only
-- [Agent-loop tutorial](/coverctl/agent-loop-tutorial/) — continuous feedback with an AI agent
+<DocsNext
+  heading="Related"
+  links={[
+    { title: 'check', href: '/coverctl/cli/check/', description: 'Single coverage check' },
+    { title: 'run', href: '/coverctl/cli/run/', description: 'Generate coverage profile only' },
+    { title: 'Agent-loop tutorial', href: '/coverctl/agent-loop-tutorial/', description: 'Continuous feedback with an AI agent' },
+  ]}
+/>

--- a/docs/src/content/docs/community.mdx
+++ b/docs/src/content/docs/community.mdx
@@ -3,6 +3,8 @@ title: Community
 description: Where the coverctl community lives — marketplace, MCP Registry, Discussions, Sponsors, and how to share PMF feedback.
 ---
 
+import DocsNext from '../../components/DocsNext.astro';
+
 coverctl is community-led. The CLI and MCP server stay Apache-2.0 forever;
 this page is the inbound surface for that motion.
 
@@ -31,3 +33,11 @@ transmitted unless you opt in.
 Standardizing coverage policy across many repos? Open a GitHub issue
 with the `platform-evaluation` label, or start from
 [For platform & DevEx teams](/coverctl/for-platform-teams/).
+
+<DocsNext
+  links={[
+    { title: 'For platform teams', href: '/coverctl/for-platform-teams/', description: 'Multi-repo coverage governance' },
+    { title: 'MCP Server', href: '/coverctl/mcp/', description: 'Agent-callable tools' },
+    { title: 'Installation', href: '/coverctl/installation/', description: 'Get the binary' },
+  ]}
+/>

--- a/docs/src/content/docs/configuration/domains.mdx
+++ b/docs/src/content/docs/configuration/domains.mdx
@@ -4,6 +4,7 @@ description: Group source paths into governance domains. Auth at 90%, utilities 
 ---
 
 import { Tabs, TabItem, Aside } from '@astrojs/starlight/components';
+import DocsNext from '../../../components/DocsNext.astro';
 
 Domains are **named groups of source paths** with their own coverage minimums. They work the same way for **all sorts of languages** — Python, TypeScript, Java, Rust, Go, and the rest. They are not language constructs and do not wrap packages, modules, or crates — they match directories and files in your repo so auth can require 90% while utilities stay at 60%.
 
@@ -249,8 +250,11 @@ package generated
 4. **Keep excludes minimal**: Only exclude truly non-testable code
 5. **Review overlaps**: Check for unintended domain assignments
 
-## See Also
-
-- [Policies](/coverctl/configuration/policies/) - Set coverage thresholds
-- [Quick start](/coverctl/quick-start/) - Per-language example configs
-- [Advanced](/coverctl/configuration/advanced/) - Annotations and more
+<DocsNext
+  heading="See Also"
+  links={[
+    { title: 'Policies', href: '/coverctl/configuration/policies/', description: 'Set coverage thresholds' },
+    { title: 'Quick start', href: '/coverctl/quick-start/', description: 'Per-language example configs' },
+    { title: 'Advanced', href: '/coverctl/configuration/advanced/', description: 'Annotations and more' },
+  ]}
+/>

--- a/docs/src/content/docs/configuration/index.mdx
+++ b/docs/src/content/docs/configuration/index.mdx
@@ -3,6 +3,8 @@ title: Policy basics
 description: What your AI coding agent sees in .coverctl.yaml. Per-domain coverage thresholds — the policy file at the heart of agent-loop coverage governance.
 ---
 
+import DocsNext from '../../../components/DocsNext.astro';
+
 `.coverctl.yaml` is what your AI coding agent reads when it calls `coverctl check`. It defines which directories belong to which **domain** (auth, payments, utilities, ...) and what coverage threshold each domain must meet. The agent reads the same file you do — there is no separate agent-mode configuration.
 
 This page is the file-format reference. For deeper patterns — diff-based enforcement, profile merging, integration tests — see [Advanced configuration](/coverctl/configuration/advanced/).
@@ -162,9 +164,12 @@ For a full worked `.coverctl.yaml`, see [Domains](/coverctl/configuration/domain
 and [Policies](/coverctl/configuration/policies/), or copy
 [`templates/coverctl.yaml`](https://github.com/klarlabs-studio/coverctl/blob/main/templates/coverctl.yaml).
 
-## Next Steps
-
-- [Domains](/coverctl/configuration/domains/) — match patterns and per-domain mins
-- [Policies](/coverctl/configuration/policies/) — defaults, warn thresholds, ratchet
-- [Advanced](/coverctl/configuration/advanced/) — files, diff, merge, annotations
-- [Monorepo Support](/coverctl/guides/monorepo/) — config inheritance and workspace support
+<DocsNext
+  heading="Next Steps"
+  links={[
+    { title: 'Domains', href: '/coverctl/configuration/domains/', description: 'Match patterns and per-domain mins' },
+    { title: 'Policies', href: '/coverctl/configuration/policies/', description: 'Defaults, warn thresholds, ratchet' },
+    { title: 'Advanced', href: '/coverctl/configuration/advanced/', description: 'Files, diff, merge, annotations' },
+    { title: 'Monorepo', href: '/coverctl/guides/monorepo/', description: 'Config inheritance and workspace support' },
+  ]}
+/>

--- a/docs/src/content/docs/configuration/policies.mdx
+++ b/docs/src/content/docs/configuration/policies.mdx
@@ -3,6 +3,8 @@ title: Configure policies
 description: Per-domain coverage thresholds in .coverctl.yaml. The policy file your AI coding agent reads when it calls coverctl check via MCP.
 ---
 
+import DocsNext from '../../../components/DocsNext.astro';
+
 Policies define the minimum coverage requirements for your project. coverctl supports domain-level and file-level policies. Domains group **source paths** (globs or Go package paths) — they are not wrappers around language packages. See [Domains](/coverctl/configuration/domains/) for both match dialects.
 
 ## Policy Structure
@@ -169,7 +171,11 @@ policy:
       min: 85
 ```
 
-## See Also
-
-- [Domains](/coverctl/configuration/domains/) - Domain configuration
-- [CI Integration](/coverctl/guides/ci-integration/) - Enforce policies in CI
+<DocsNext
+  heading="See Also"
+  links={[
+    { title: 'Domains', href: '/coverctl/configuration/domains/', description: 'Domain configuration' },
+    { title: 'CI Integration', href: '/coverctl/guides/ci-integration/', description: 'Enforce policies in CI' },
+    { title: 'check', href: '/coverctl/cli/check/', description: 'Enforce policies from the CLI' },
+  ]}
+/>

--- a/docs/src/content/docs/installation.mdx
+++ b/docs/src/content/docs/installation.mdx
@@ -4,6 +4,7 @@ description: Install coverctl — agent-loop coverage governance for polyglot co
 ---
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';
+import DocsNext from '../../components/DocsNext.astro';
 
 coverctl is a single self-contained binary. It runs locally — no SaaS account, no source upload. After install, run `coverctl mcp doctor` to validate setup.
 
@@ -76,7 +77,11 @@ coverctl supports shell completions for bash, zsh, and fish.
   </TabItem>
 </Tabs>
 
-## Next Steps
-
-- [Quick Start](/coverctl/quick-start/) - Create your first configuration
-- [CLI Reference](/coverctl/cli/) - Learn about all available commands
+<DocsNext
+  heading="Next Steps"
+  links={[
+    { title: 'Quick Start', href: '/coverctl/quick-start/', description: 'Create your first configuration' },
+    { title: 'CLI Reference', href: '/coverctl/cli/', description: 'Learn about all available commands' },
+    { title: 'MCP Server', href: '/coverctl/mcp/', description: 'Wire coverctl into your AI coding agent' },
+  ]}
+/>

--- a/docs/src/content/docs/mcp.mdx
+++ b/docs/src/content/docs/mcp.mdx
@@ -5,6 +5,7 @@ description: Connect coverctl to Claude Code, Cursor, Cline, Aider and other Mod
 
 import { Tabs, TabItem, Aside } from '@astrojs/starlight/components';
 import AgentLoop from '../../components/AgentLoop.astro';
+import DocsNext from '../../components/DocsNext.astro';
 
 coverctl ships an [MCP](https://modelcontextprotocol.io) server so AI coding agents can ask for coverage feedback inline — domain-aware policy results, debt rankings, threshold suggestions, and per-file deltas — without leaving the edit loop.
 
@@ -245,3 +246,11 @@ Find the path with `which coverctl`.
 **Path errors.** All path inputs must be relative to the working directory. Absolute paths are rejected. Pass `Profile=".cover/coverage.out"` not `Profile="/abs/path/coverage.out"`.
 
 **Rate-limit error on `pr-comment`.** The PR was already updated five times in the last five minutes. Wait it out, or use `dryRun=true` to generate the comment body without posting.
+
+<DocsNext
+  links={[
+    { title: 'check', href: '/coverctl/cli/check/', description: 'CLI wedge command agents call via MCP' },
+    { title: 'Other commands', href: '/coverctl/cli/other/', description: 'suggest, debt, compare, pr-comment' },
+    { title: 'Agent-loop tutorial', href: '/coverctl/agent-loop-tutorial/', description: 'End-to-end agent workflow' },
+  ]}
+/>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Continues the health-improvements backlog (**Still open #2 — Site content infra**):

- Add reusable `DocsNext` Starlight component (`docs/src/components/DocsNext.astro`) for end-of-page wayfinding.
- Wire it onto CLI (`index`, `check`, `run`, `report`, `init`, `watch`, `other`), configuration (`index`, `domains`, `policies`), installation, community, and MCP pages.
- Slim `cli/other.mdx` into a compact Diataxis-style command reference (~375 lines removed).
- Mark DocsNext + `other.mdx` polish as shipped in `docs/backlog.md` (blog/RSS remains open).

## Test plan

- [x] Docs site builds (`npm run build` in `docs/` — 32 pages OK)
- [ ] Spot-check Next cards on `/cli/other/`, `/configuration/`, `/mcp/`
- [x] Confirm import paths resolve for nested vs top-level content pages

Supersedes remaining docs work from the assessment track; assessment-only PR #129 remains empty vs `main` if still open.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0055d-043b-7ef3-9006-1a40c51cbf64?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0055d-043b-7ef3-9006-1a40c51cbf64&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

