### PR TITLE
chore(security): nox remediation (deps + actions)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -43,7 +43,7 @@ jobs:
         run: nox scan . -format sarif -output nox-results || true
       - name: Upload SARIF to GitHub Security
         if: always() && hashFiles('nox-results/results.sarif') != ''
-        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
+        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           # No category — must match the historical go.yml:security upload
           # identity (the pre-rename workflow did not set category).

--- a/.github/workflows/polyglot-smoke.yml
+++ b/.github/workflows/polyglot-smoke.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Install cargo-llvm-cov
         if: matrix.lang == 'rust'
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@288e746965032cfcc232e09af2daf5f23c14d780 # v2.86.1
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
Automated remediation by `nox fix --actions`: OSV-vulnerable dependency upgrades plus outdated and mutable GitHub Actions pins bumped to their SHA-pinned latest release. Replaces dependabot.